### PR TITLE
refactor(useForm): disabled the watch mode of getFormState() for even…

### DIFF
--- a/.changeset/light-singers-joke.md
+++ b/.changeset/light-singers-joke.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+refactor(useForm): disabled the watch mode of getFormState() for event & remove un-necessary variable

--- a/src/index.ts
+++ b/src/index.ts
@@ -414,7 +414,8 @@ const useForm = <V extends FormValues = FormValues>({
 
   const getOptions = useCallback(
     () => ({
-      getFormState: (path: string, watch = false) => getFormState(path, watch),
+      getFormState: ((path: string, watch = false) =>
+        getFormState(path, watch)) as GetFormState,
       setErrors,
       setFieldError,
       setValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,8 +244,7 @@ const useForm = <V extends FormValues = FormValues>({
 
     return Promise.all(promises).then((errors) =>
       names.reduce((acc, cur, idx) => {
-        const error = errors[idx];
-        acc = { ...acc, ...(error ? set({}, cur, error) : {}) };
+        acc = { ...acc, ...(errors[idx] ? set({}, cur, errors[idx]) : {}) };
         return acc;
       }, {})
     );
@@ -415,7 +414,7 @@ const useForm = <V extends FormValues = FormValues>({
 
   const getOptions = useCallback(
     () => ({
-      getFormState,
+      getFormState: (path: string, watch = false) => getFormState(path, watch),
       setErrors,
       setFieldError,
       setValues,


### PR DESCRIPTION
- Refactor(useForm): disabled the watch mode of `getFormState()` for callback options
- Refactor(useForm): remove un-necessary variable