### PR TITLE
refactor(useForm): use requestIdleCallback instead of scheduler to reduce bundle size

### DIFF
--- a/.changeset/brave-beans-relax.md
+++ b/.changeset/brave-beans-relax.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+refactor(useForm): use requestIdleCallback instead of scheduler

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "umd:main": "dist/index.umd.production.min.js",
   "unpkg": "dist/index.umd.production.min.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "link-pkg": "npm link examples/node_modules/react && yarn link",
     "dev": "yarn clean:build && yarn copy:type && rollup -c rollup/config.js -w",
@@ -64,8 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "fast-deep-equal": "^3.1.3",
-    "scheduler": "^0.20.1"
+    "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/src/runWithLowPriority.ts
+++ b/src/runWithLowPriority.ts
@@ -1,0 +1,16 @@
+window.requestIdleCallback =
+  window.requestIdleCallback ||
+  ((callback: RequestIdleCallback) => {
+    const start = Date.now();
+    return setTimeout(
+      () =>
+        callback({
+          didTimeout: false,
+          timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
+        }),
+      1
+    );
+  });
+
+export default (callback: () => any): void =>
+  window.requestIdleCallback(callback, { timeout: 2000 });

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,1 +1,16 @@
 declare const __DEV__: boolean;
+
+interface RequestIdleCallback {
+  (deadline: {
+    readonly didTimeout: boolean;
+    timeRemaining: () => number;
+  }): void;
+}
+
+interface Window {
+  requestIdleCallback: (
+    callback: RequestIdleCallback,
+    options?: { timeout: number }
+  ) => any;
+  cancelIdleCallback: (handle: any) => void;
+}

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1,9 +1,4 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import {
-  unstable_LowPriority,
-  unstable_runWithPriority,
-  unstable_scheduleCallback,
-} from "scheduler";
 
 import {
   Config,
@@ -29,6 +24,7 @@ import {
 } from "./types";
 import useLatest from "./useLatest";
 import useState from "./useState";
+import runWithLowPriority from "./runWithLowPriority";
 import {
   arrayToMap,
   deepMerge,
@@ -416,10 +412,7 @@ export default <V extends FormValues = FormValues>({
   ]);
 
   const validateFormWithLowPriority = useCallback(
-    () =>
-      unstable_runWithPriority(unstable_LowPriority, () =>
-        unstable_scheduleCallback(unstable_LowPriority, validateForm as any)
-      ),
+    () => runWithLowPriority(validateForm),
     [validateForm]
   );
 


### PR DESCRIPTION
- Refactor(useForm): use [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) instead of [scheduler](https://www.npmjs.com/package/scheduler) to reduce bundle size