### PR TITLE
feat(useForm): use "valueAsNumber" instead "parseFloat()" for converting data

### DIFF
--- a/.changeset/eighty-balloons-stare.md
+++ b/.changeset/eighty-balloons-stare.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+feat(useForm): use `valueAsNumber` instead `parseFloat()` for converting data

--- a/app/src/BasicForm/index.tsx
+++ b/app/src/BasicForm/index.tsx
@@ -138,10 +138,10 @@ export default (): JSX.Element => {
     ])
   ); */
   // console.log("LOG ===> ", getState("values.dynamicText1"));
-  /* console.log(
+  console.log(
     "LOG ===> formState: ",
     getState({
-      // values: "values",
+      values: "values",
       // errors: "errors",
       // touched: "touched",
       // isDirty: "isDirty",
@@ -152,11 +152,8 @@ export default (): JSX.Element => {
       // isSubmitted: "isSubmitted",
       // submitCount: "submitCount",
     })
-  ); */
+  );
   const errors = getState("errors");
-  console.log("LOG ===> ", errors);
-  // const errors = getState("text.nest", { target: "errors" });
-  // console.log("LOG ===> ", errors);
 
   useEffect(() => {
     // validateField("text.nest");

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -145,7 +145,7 @@ export default <V extends FormValues = FormValues>({
       let value = field.value as any;
 
       if (isNumberField(field) || isRangeField(field))
-        value = field.valueAsNumber;
+        value = field.valueAsNumber || "";
 
       if (isCheckboxField(field)) {
         if (options) {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -145,7 +145,7 @@ export default <V extends FormValues = FormValues>({
       let value = field.value as any;
 
       if (isNumberField(field) || isRangeField(field))
-        value = value ? parseFloat(value) : "";
+        value = field.valueAsNumber;
 
       if (isCheckboxField(field)) {
         if (options) {


### PR DESCRIPTION
- Feat(useForm): use `valueAsNumber` instead `parseFloat()` for converting data