### PR TITLE
Refactor(useForm): add warning for getting "values" state alone

### DIFF
--- a/.changeset/tiny-kiwis-wave.md
+++ b/.changeset/tiny-kiwis-wave.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+refactor(useForm): add warning for getting `values` state alone

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -1,3 +1,22 @@
-const Playground = (): JSX.Element => <h1>Playground</h1>;
+import { useForm } from "react-cool-form";
+
+interface FormValues {
+  text: "";
+}
+
+const Playground = (): JSX.Element => {
+  const { form, getState } = useForm<FormValues>({
+    defaultValues: { text: "" },
+  });
+  const value = getState({ text: "text" }, { target: "values" });
+  console.log("LOG ===> ", value);
+
+  return (
+    <form ref={form} noValidate>
+      <input name="text" />
+      <input type="submit" />
+    </form>
+  );
+};
 
 export default Playground;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -297,7 +297,14 @@ export default <V extends FormValues = FormValues>({
 
   const getState = useCallback<GetState>(
     (path, { target, watch = true, filterUntouchedErrors = true } = {}) => {
-      const getPath = (path: string) => (target ? `${target}.${path}` : path);
+      const getPath = (path: string) => {
+        if (path === "values" && !target && watch)
+          warn(
+            '💡 react-cool-form > getState: Get the "values" alone may cause unnecessary re-renders. If you know what you\'re doing, please ignore this warning.'
+          );
+
+        return target ? `${target}.${path}` : path;
+      };
       const errorsEnhancer = (path: string, state: any) => {
         if (!watch || !filterUntouchedErrors || !path.startsWith("errors"))
           return state;


### PR DESCRIPTION
- Refactor(useForm): add warning for getting `values` state alone