### PR TITLE
Refactor(useForm): use "formState" instead of the "getState" method for event handlers

### DIFF
--- a/.changeset/light-pots-exist.md
+++ b/.changeset/light-pots-exist.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+refactor(useForm): use `formState` instead of the `getState` method for event handlers

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useForm } from "react-cool-form";
 
 interface FormValues {
@@ -12,24 +11,19 @@ const defaultValues = {
 };
 
 const Playground = (): JSX.Element => {
-  const { form, getState, setFieldValue, setValues } = useForm<FormValues>({
+  const { form } = useForm<FormValues>({
     defaultValues,
-    onSubmit: (values) => console.log(values),
+    onSubmit: (values, { formState }) => {
+      console.log("LOG ===> onSubmit: ", formState);
+    },
+    onError: (errors, { formState }) => {
+      console.log("LOG ===> onError: ", formState);
+    },
   });
-  const state = getState({ touched: "touched", dirtyFields: "dirtyFields" });
-  console.log("LOG ===> state: ", state);
-
-  useEffect(() => {
-    // setFieldValue("t2", "test");
-    /* setValues(
-      { t1: "test", t2: "test" },
-      { touchedFields: ["t1", "t2"], dirtyFields: ["t1", "t2"] }
-    ); */
-  }, [setFieldValue, setValues]);
 
   return (
     <form ref={form} noValidate>
-      <input name="t1" />
+      <input name="t1" required />
       <input name="t2" />
       <input type="submit" />
     </form>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,7 +68,16 @@ export type FieldParsers = Record<
   }
 >;
 
-type Options<V> = Omit<Return<V>, "form" | "field" | "submit" | "controller">;
+interface Options<V> {
+  formState: FormState<V>;
+  setErrors: SetErrors<V>;
+  setFieldError: SetFieldError;
+  setValues: SetValues<V>;
+  setFieldValue: SetFieldValue;
+  validateForm: ValidateForm<V>;
+  validateField: ValidateField;
+  reset: Reset<V>;
+}
 
 interface OnReset<V> {
   (

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -22,7 +22,16 @@ declare module "react-cool-form" {
     submitCount: number;
   }>;
 
-  type Options<V> = Omit<Return<V>, "form" | "field" | "submit" | "controller">;
+  interface Options<V> {
+    formState: FormState<V>;
+    setErrors: SetErrors<V>;
+    setFieldError: SetFieldError;
+    setValues: SetValues<V>;
+    setFieldValue: SetFieldValue;
+    validateForm: ValidateForm<V>;
+    validateField: ValidateField;
+    reset: Reset<V>;
+  }
 
   export interface OnReset<V = FormValues> {
     (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -605,8 +605,7 @@ export default <V extends FormValues = FormValues>({
 
   const getOptions = useCallback(
     () => ({
-      getState: ((path, options = { watch: false }) =>
-        getState(path, options)) as GetState,
+      formState: stateRef.current,
       setErrors,
       setFieldError,
       setValues,
@@ -615,11 +614,11 @@ export default <V extends FormValues = FormValues>({
       validateField,
     }),
     [
-      getState,
       setErrors,
       setFieldError,
       setFieldValue,
       setValues,
+      stateRef,
       validateField,
       validateForm,
     ]


### PR DESCRIPTION
- Refactor(useForm): use `formState` instead of the `getState` method for event handlers