### PR TITLE
Fix(useForm): do not count the "valid" key as an error when using built-in validation with state mode

### DIFF
--- a/.changeset/popular-cougars-cover.md
+++ b/.changeset/popular-cougars-cover.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useForm): do not count the `valid` key as error when use built-in validation with state mode

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -9,14 +9,16 @@ const defaultValues = {
 };
 
 const Playground = (): JSX.Element => {
-  const { form, field } = useForm<FormValues>({
+  const { form } = useForm<FormValues>({
     defaultValues,
+    builtInValidationMode: "state",
     onSubmit: (values) => console.log("LOG ===> onSubmit", values),
+    onError: (errors) => console.log("LOG ===> onError", errors),
   });
 
   return (
     <form ref={form} noValidate>
-      <input name="t1" type="date" ref={field({ valueAsDate: true })} />
+      <input name="t1" required />
       <input type="submit" />
     </form>
   );

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -399,9 +399,11 @@ export default <V extends FormValues = FormValues>({
 
       if (builtInValidationMode === "message") return field.validationMessage;
 
-      // @ts-expect-error
       // eslint-disable-next-line no-restricted-syntax
-      for (const k in field.validity) if (field.validity[k]) return k;
+      for (const k in field.validity) {
+        // @ts-expect-error
+        if (k !== "valid" && field.validity[k]) return k;
+      }
 
       return undefined;
     },


### PR DESCRIPTION
- Fix(useForm): do not count the `valid` key as an error when using built-in validation with state mode