### PR TITLE
Breaking Change: Rename the option of "getState" from "filterUntouchedError" to "errorWithTouched" and change the default to "false"

### DIFF
--- a/.changeset/tiny-chefs-poke.md
+++ b/.changeset/tiny-chefs-poke.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Feat(useForm): rename the option of `getState` from `filterUntouchedError` to `errorWithTouched`

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ const App = () => {
     // The event only triggered when the form is valid
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  // React Cool Form filters the error of an un-blurred field by default (i.e. the "filterUntouchedError" option)
-  // Which helps the user focus on typing without being annoying
-  const errors = getState("errors", { filterUntouchedError: true });
+  // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
+  // Which helps the user focus on typing without being annoyed by the error message
+  const errors = getState("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -1,39 +1,32 @@
 import { useForm } from "react-cool-form";
+import { TextField } from "@material-ui/core";
 
 export default () => {
-  const { form, getState, runValidation, field } = useForm({
-    defaultValues: { t1: "", t2: "" },
-    validate: (values) => {
+  const { form, getState, setValue, setTouched, submit } = useForm({
+    defaultValues: { username: "" },
+    // ignoreFields: ["username"], // You can also ignore the field by this option
+    validate: ({ username }) => {
       const errors = {};
-      // if (!values.t1.length) errors.t2 = "Form Required";
+      // @ts-expect-error
+      if (!username.length) errors.username = "Required";
       return errors;
     },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  console.log(
-    "LOG ===> ",
-    getState(
-      { errors: "errors" },
-      {
-        filterUntouchedError: false,
-      }
-    )
-  );
+  const [value, errors] = getState(["values.username", "errors"]);
 
   return (
-    <form ref={form} noValidate>
-      <input name="t1" ref={field((value) => false)} />
-      <input name="t2" required />
+    <form ref={form}>
+      <TextField
+        name="username" // Used for the "ignoreFields" option
+        value={value}
+        onChange={(e) => setValue("username", e.target.value)} // Update the field's value and set it as touched
+        onBlur={() => setTouched("username")} // Set the field as touched for displaying error (if it's not touched)
+        error={!!errors.username}
+        helperText={errors.username}
+        inputProps={{ "data-rcf-ignore": true }} // Ignore the field via the pre-defined data attribute
+      />
       <input type="submit" />
-      <button
-        type="button"
-        onClick={async () => {
-          const res = await runValidation("t1");
-          console.log(res);
-        }}
-      >
-        Validate
-      </button>
     </form>
   );
 };

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -299,6 +299,8 @@ clearErrors(["foo.bar", "foo.baz"]); // Clears "foo.bar" and "foo.baz" respectiv
 
 This method allows us to manually run validation for the field(s) or form. It returns a boolean that indicates the validation results, `true` means valid, `false` otherwise.
 
+- Please note, when using with the [Filter Untouched Field Errors](../getting-started/form-state#filter-untouched-field-errors), only the errors of the touched fields are accessible.
+
 ```js
 const { runValidation } = useForm();
 

--- a/docs/getting-started/3rd-party-ui-libraries.md
+++ b/docs/getting-started/3rd-party-ui-libraries.md
@@ -221,11 +221,6 @@ const App = () => {
   });
   const [value, errors] = getState(["values.username", "errors"]);
 
-  const handleSubmit = (e: any) => {
-    setTouched("username"); // Set the field as touched for displaying error (if it's not touched)
-    submit(e);
-  };
-
   return (
     <form ref={form}>
       <TextField
@@ -237,9 +232,7 @@ const App = () => {
         helperText={errors.username}
         inputProps={{ "data-rcf-ignore": true }} // Ignore the field via the pre-defined data attribute
       />
-      <button type="button" onClick={handleSubmit}>
-        Submit
-      </button>
+      <input type="submit" />
     </form>
   );
 };

--- a/docs/getting-started/complex-structures.md
+++ b/docs/getting-started/complex-structures.md
@@ -27,7 +27,7 @@ You can play around with the following example to get better understanding of ho
 ```js
 import { useForm } from "react-cool-form";
 
-const FieldGroup = ({ name, onUpdate, onClear, ...rest }) => (
+const FieldGroup = ({ name, onUpdate, onClear }) => (
   <>
     <input name={name} placeholder={name} />
     <div>

--- a/docs/getting-started/form-state.md
+++ b/docs/getting-started/form-state.md
@@ -8,7 +8,7 @@ Building highly performant forms is the duty of React Cool Form. It minimizes th
 - No unnecessary re-renders by leveraging the power of [uncontrolled components](https://reactjs.org/docs/uncontrolled-components.html)
 - No unnecessary re-renders when [using the form state](#using-the-form-state)
 - No unnecessary re-renders when receives the same form state (since last re-rendering)
-- [Filters the errors of untouched fields](#filters-untouched-field-errors) for better UX (refer to [theory](https://www.nngroup.com/articles/errors-forms-design-guidelines) at No.7)
+- [Filters the errors of untouched fields](#filters-untouched-field-errors) for better UX (refer to the [UX research](https://www.nngroup.com/articles/errors-forms-design-guidelines) at No.7)
 
 Here we will explore the form state and some [best practices for using it](#best-practices).
 
@@ -112,9 +112,9 @@ const SomeHandler = () => {
 
 ### Filters Untouched Field Errors
 
-Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, React Cool Form auto filters the errors of untouched fields for you. However, you can disable this feature by setting the `filterUntouchedError` option to `false`.
+Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `getState`'s `errorWithTouched` option.
 
-> 💡 Check the [Displaying Error Messages](./validation-guide#displaying-error-messages) to learn more about it.
+> 💡 This feature filters any errors of the untouched fields. So when validating with the [runValidation](../api-reference/use-form#runvalidation), please ensure it's triggered after the field(s) is (are) touched.
 
 ```js
 const { getState } = useForm();
@@ -125,8 +125,10 @@ const { getState } = useForm();
 const errors = getState("errors");
 
 // Returns { foo: "Required" }
-const errors = getState("errors", { filterUntouchedError: false });
+const errors = getState("errors", { errorWithTouched: true }); // Default is "false"
 
 // Returns { foo: "Required" }, the feature only available in watch mode
 const errors = getState("errors", { watch: false });
 ```
+
+👉🏻 Check the [Displaying Error Messages](./validation-guide#displaying-error-messages) to learn more about it.

--- a/docs/getting-started/form-state.md
+++ b/docs/getting-started/form-state.md
@@ -8,7 +8,7 @@ Building highly performant forms is the duty of React Cool Form. It minimizes th
 - No unnecessary re-renders by leveraging the power of [uncontrolled components](https://reactjs.org/docs/uncontrolled-components.html)
 - No unnecessary re-renders when [using the form state](#using-the-form-state)
 - No unnecessary re-renders when receives the same form state (since last re-rendering)
-- [Filters the errors of untouched fields](#filters-untouched-field-errors) for better UX (refer to the [UX research](https://www.nngroup.com/articles/errors-forms-design-guidelines) at No.7)
+- [Filters the errors of untouched fields](#filter-untouched-field-errors) for better UX (refer to the [UX research](https://www.nngroup.com/articles/errors-forms-design-guidelines) at No.7)
 
 Here we will explore the form state and some [best practices for using it](#best-practices).
 
@@ -110,7 +110,7 @@ const SomeHandler = () => {
 };
 ```
 
-### Filters Untouched Field Errors
+### Filter Untouched Field Errors
 
 Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `getState`'s `errorWithTouched` option.
 

--- a/docs/getting-started/form-submission.md
+++ b/docs/getting-started/form-submission.md
@@ -77,7 +77,7 @@ Are there any errors?
 
 - Sets `formState.isSubmitting` to `false`
 
-> 💡 Check the [Form State](./form-state#about-the-form-state) to learn more about it.
+👉🏻 Check the [Form State](./form-state#about-the-form-state) to learn more about it.
 
 ## Manually Triggering Submission
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -8,7 +8,7 @@ Building forms in [React](https://reactjs.org) might be a challenge. We have to 
 
 As a React developer, there're two strategies of implementing forms, the [controlled components](https://reactjs.org/docs/forms.html#controlled-components) and [uncontrolled components](https://reactjs.org/docs/uncontrolled-components.html), each has its advantages and timing of use. The controlled components serve form state as [the single source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth). However, the uncontrolled components make our code more **concise** and **performant**.
 
-React Cool Form combines these advantages and references the [UX theory](https://www.nngroup.com/articles/errors-forms-design-guidelines) of [Nielsen Norman Group](https://www.nngroup.com) as the basis for our [API](./api-reference/use-form) design to help you beat all kinds of forms 👊🏻.
+React Cool Form combines these advantages and references the [UX research](https://www.nngroup.com/articles/errors-forms-design-guidelines) of [Nielsen Norman Group](https://www.nngroup.com) as the basis for our [API](./api-reference/use-form) design to help you beat all kinds of forms 👊🏻.
 
 ## Requirement
 
@@ -63,9 +63,9 @@ const App = () => {
     // The event only triggered when the form is valid
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  // React Cool Form filters the error of an un-blurred field by default (i.e. the "filterUntouchedError" option)
-  // Which helps the user focus on typing without being annoyed
-  const errors = getState("errors", { filterUntouchedError: true });
+  // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
+  // Which helps the user focus on typing without being annoyed by the error message
+  const errors = getState("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/validation-guide.md
+++ b/docs/getting-started/validation-guide.md
@@ -288,7 +288,7 @@ When validating with mixed ways, the results are deeply merged according to the 
 
 ## Displaying Error Messages
 
-All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [getState](../api-reference/use-form#getstate) method. The `getState` method is designed to filter the errors of untouched fields by default, which based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can disable the feature by setting the `filterUntouchedError` option to `false` (see [related doc](./form-state#filters-untouched-field-errors)).
+All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [getState](../api-reference/use-form#getstate) method. The `getState` method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filters-untouched-field-errors)).
 
 [![Edit RCF - Quick start](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/rcf-quick-start-j8p1l?fontsize=14&hidenavigation=1&theme=dark)
 
@@ -300,9 +300,9 @@ const App = () => {
     defaultValues: { username: "", email: "", password: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  // By default, the errors of untouched fields are filtered out, which helps the user focus on typing without being annoyed
-  // You can disable this feature by setting the "filterUntouchedError" option to false
-  const errors = getState("errors", { filterUntouchedError: true });
+  // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
+  // Which helps the user focus on typing without being annoyed by the error message
+  const errors = getState("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/validation-guide.md
+++ b/docs/getting-started/validation-guide.md
@@ -288,7 +288,7 @@ When validating with mixed ways, the results are deeply merged according to the 
 
 ## Displaying Error Messages
 
-All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [getState](../api-reference/use-form#getstate) method. The `getState` method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filters-untouched-field-errors)).
+All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [getState](../api-reference/use-form#getstate) method. The `getState` method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filter-untouched-field-errors)).
 
 [![Edit RCF - Quick start](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/rcf-quick-start-j8p1l?fontsize=14&hidenavigation=1&theme=dark)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,7 +129,7 @@ export interface GetState {
     options?: {
       target?: string;
       watch?: boolean;
-      filterUntouchedError?: boolean;
+      errorWithTouched?: boolean;
     }
   ): any;
 }

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -22,7 +22,7 @@ declare module "react-cool-form" {
       options?: {
         target?: string;
         watch?: boolean;
-        filterUntouchedError?: boolean;
+        errorWithTouched?: boolean;
       }
     ): any;
   }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -309,7 +309,7 @@ export default <V extends FormValues = FormValues>({
   );
 
   const getState = useCallback<GetState>(
-    (path, { target, watch = true, filterUntouchedError = true } = {}) => {
+    (path, { target, watch = true, errorWithTouched = false } = {}) => {
       if (!path) return undefined;
 
       const getPath = (path: string) => {
@@ -327,7 +327,7 @@ export default <V extends FormValues = FormValues>({
       const errorsEnhancer = (path: string, state: any) => {
         if (
           !watch ||
-          !filterUntouchedError ||
+          !errorWithTouched ||
           !path.startsWith("errors") ||
           !state ||
           isEmptyObject(state)


### PR DESCRIPTION
- Breaking Change: Rename the option of `getState` from `filterUntouchedError` to `errorWithTouched`
- Breaking Change: The default of the `errorWithTouched` now is `false`