### PR TITLE
Fix(useForm): "dirty" and "isDirty" state not work correctly with reference type values

### DIFF
--- a/.changeset/purple-hats-appear.md
+++ b/.changeset/purple-hats-appear.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useForm): `dirty` and `isDirty` state not work correctly with reference type values

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
 import { useCallback, useEffect, useRef } from "react";
+import { dequal } from "dequal/lite";
 
 import {
   ClearErrors,
@@ -590,8 +591,10 @@ export default <V extends FormValues = FormValues>({
     (name: string) =>
       setDirty(
         name,
-        get(stateRef.current.values, name) !==
+        !dequal(
+          get(stateRef.current.values, name),
           get(initialStateRef.current.values, name)
+        )
       ),
     [setDirty, stateRef]
   );


### PR DESCRIPTION
- Fix(useForm): `dirty` and `isDirty` state not work correctly with reference type values