### PR TITLE
Rename "select" method to "mon" (a.k.a monitor)

### DIFF
--- a/.changeset/giant-gorillas-smoke.md
+++ b/.changeset/giant-gorillas-smoke.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Feat(useForm): rename `select` method to `watch` for better understanding

--- a/.changeset/nervous-walls-sniff.md
+++ b/.changeset/nervous-walls-sniff.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Change `select` method to `mon` (a.k.a monitor)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     // (Strongly advise) Provide the default values just like we use React state
     defaultValues: { username: "", email: "", password: "" },
     // The event only triggered when the form is valid
@@ -70,7 +70,7 @@ const App = () => {
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = select("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     // (Strongly advise) Provide the default values just like we use React state
     defaultValues: { username: "", email: "", password: "" },
     // The event only triggered when the form is valid
@@ -70,7 +70,7 @@ const App = () => {
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = mon("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/docs/api-reference/use-form-state.md
+++ b/docs/api-reference/use-form-state.md
@@ -3,7 +3,7 @@ id: use-form-state
 title: useFormState
 ---
 
-This hook helps us to isolate re-rendering at the component level for performance optimization (see [related article](https://overreacted.io/before-you-memo)). The hook has the similar API design to the [watch](../api-reference/use-form#watch) method of the `useForm` that maintain a consistent DX for us. Check the [Isolating Re-rendering](../getting-started/form-state#isolating-re-rendering) to learn more.
+This hook helps us to isolate re-rendering at the component level for performance optimization (see [related article](https://overreacted.io/before-you-memo)). The hook has the similar API design to the [mon](../api-reference/use-form#mon) method of the `useForm` that maintain a consistent DX for us. Check the [Isolating Re-rendering](../getting-started/form-state#isolating-re-rendering) to learn more.
 
 ```js
 const values = useFormState(path, config);

--- a/docs/api-reference/use-form-state.md
+++ b/docs/api-reference/use-form-state.md
@@ -3,7 +3,7 @@ id: use-form-state
 title: useFormState
 ---
 
-This hook helps us to isolate re-rendering at the component level for performance optimization (see [related article](https://overreacted.io/before-you-memo)). The hook has the similar API design to the [select](../api-reference/use-form#select) method of the `useForm` that maintain a consistent DX for us. Check the [Isolating Re-rendering](../getting-started/form-state#isolating-re-rendering) to learn more.
+This hook helps us to isolate re-rendering at the component level for performance optimization (see [related article](https://overreacted.io/before-you-memo)). The hook has the similar API design to the [watch](../api-reference/use-form#watch) method of the `useForm` that maintain a consistent DX for us. Check the [Isolating Re-rendering](../getting-started/form-state#isolating-re-rendering) to learn more.
 
 ```js
 const values = useFormState(path, config);

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -225,11 +225,11 @@ If you just want to validate the field, there's a shortcut for it:
 <input nam="rcf" ref={field((value) => !value.length && "Required")} />
 ```
 
-### watch
+### mon
 
 `(path: string | string[] | Record<string, string>, options?: Object) => any`
 
-This method provides us a performant way to use the form state with minimized re-renders. Check the [Form State](../getting-started/form-state) to learn more.
+Mon means "monitor", the method provides us a performant way to use the form state with minimized re-renders. Check the [Form State](../getting-started/form-state) to learn more.
 
 ### getState
 

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -225,11 +225,11 @@ If you just want to validate the field, there's a shortcut for it:
 <input nam="rcf" ref={field((value) => !value.length && "Required")} />
 ```
 
-### select
+### watch
 
 `(path: string | string[] | Record<string, string>, options?: Object) => any`
 
-This method provides us a performant way to use the form state. Check the [Form State](../getting-started/form-state) to learn more.
+This method provides us a performant way to use the form state with minimized re-renders. Check the [Form State](../getting-started/form-state) to learn more.
 
 ### getState
 

--- a/docs/getting-started/3rd-party-ui-libraries.md
+++ b/docs/getting-started/3rd-party-ui-libraries.md
@@ -25,11 +25,11 @@ import {
 } from "@material-ui/core";
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { username: "", framework: "", fruit: [] },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = watch("errors");
+  const errors = mon("errors");
 
   return (
     <form ref={form} noValidate>
@@ -163,7 +163,7 @@ const Field = ({ as, name, onChange, onBlur, ...restProps }) => {
 };
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { username: "" },
     // excludeFields: ["username"], // You can also exclude the field here
     validate: ({ username }) => {
@@ -173,7 +173,7 @@ const App = () => {
     },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = watch("errors");
+  const errors = mon("errors");
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/3rd-party-ui-libraries.md
+++ b/docs/getting-started/3rd-party-ui-libraries.md
@@ -25,11 +25,11 @@ import {
 } from "@material-ui/core";
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     defaultValues: { username: "", framework: "", fruit: [] },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = select("errors");
+  const errors = watch("errors");
 
   return (
     <form ref={form} noValidate>
@@ -163,7 +163,7 @@ const Field = ({ as, name, onChange, onBlur, ...restProps }) => {
 };
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     defaultValues: { username: "" },
     // excludeFields: ["username"], // You can also exclude the field here
     validate: ({ username }) => {
@@ -173,7 +173,7 @@ const App = () => {
     },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = select("errors");
+  const errors = watch("errors");
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/form-state.md
+++ b/docs/getting-started/form-state.md
@@ -31,36 +31,36 @@ Form state is an `object` containing the following properties:
 
 ## Using the Form State
 
-React Cool Form provides a powerful [watch](../api-reference/use-form#watch) method to help us avoid unnecessary re-renders when using the form state.
+React Cool Form provides a powerful API: [mon](../api-reference/use-form#mon) (a.k.a monitor) to help us avoid unnecessary re-renders when using the form state.
 
 ### Accessing the State
 
-Due to the support of [complex structures](./complex-structures), the `watch` method allows us to use [dot](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Dot_notation)-and-[bracket](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Bracket_notation) notation to get the form state.
+Due to the support of [complex structures](./complex-structures), the `mon` method allows us to use [dot](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Dot_notation)-and-[bracket](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Bracket_notation) notation to get the form state.
 
 ```js
-const { watch } = useForm();
+const { mon } = useForm();
 
 // Returns { name: "Welly", orders: ["🍕", "🥤"] }
 // Re-renders the component when either "values.user" or "values.user.<property>" changes
-const user = watch("values.user");
+const user = mon("values.user");
 
 // Returns "Welly", re-renders the component when "values.user.name" changes
-const name = watch("values.user.name");
+const name = mon("values.user.name");
 
 // Returns "🍕", re-renders the component when "values.user.orders" changes
-const pizza = watch("values.user.orders[0]");
+const pizza = mon("values.user.orders[0]");
 ```
 
 We can construct an array/object with multiple state-picks inside like the following example:
 
 ```js
-const { watch } = useForm();
+const { mon } = useForm();
 
 // Array pick, re-renders the component when either "values.foo" or "values.bar" changes
-const [foo, bar] = watch(["values.foo", "values.bar"]);
+const [foo, bar] = mon(["values.foo", "values.bar"]);
 
 // Object pick, re-renders the component when either "values.foo" or "values.bar" changes
-const { foo, bar } = watch({ foo: "values.foo", bar: "values.bar" });
+const { foo, bar } = mon({ foo: "values.foo", bar: "values.bar" });
 ```
 
 From the code above, you can see we are getting the values of a specific target, it's kind of verbose. We can reduce it by the `target` option.
@@ -68,37 +68,37 @@ From the code above, you can see we are getting the values of a specific target,
 <!-- prettier-ignore-start -->
 ```js
 // Current state: { values: { foo: "🍎", bar: "🥝", baz: "🍋" } }
-const [foo, bar, baz] = watch(["foo", "bar", "baz"], { target: "values" });
+const [foo, bar, baz] = mon(["foo", "bar", "baz"], { target: "values" });
 
 // Current state: { values: { nest: { foo: "🍎", bar: "🥝", baz: "🍋" } } }
-const [foo, bar, baz] = watch(["foo", "bar", "baz"], { target: "values.nest" });
+const [foo, bar, baz] = mon(["foo", "bar", "baz"], { target: "values.nest" });
 ```
 <!-- prettier-ignore-end -->
 
 ### Best Practices
 
-Every time we access a value from the form state via the `watch` method, it will listen the changes of the value and trigger re-renders only when necessary. Thus, there're some guidelines for us to use the form state. General speaking, when getting a value from an `object` state, **more specific more performant**.
+Every time we access a value from the form state via the `mon` method, it will listen the changes of the value and trigger re-renders only when necessary. Thus, there're some guidelines for us to use the form state. General speaking, when getting a value from an `object` state, **more specific more performant**.
 
 ```js
-const { watch } = useForm();
+const { mon } = useForm();
 
 // 👎🏻 You can, but not recommended because it will cause the component to update on every value change
-const values = watch("values");
+const values = mon("values");
 // 👍🏻 For the form's values, we always recommended getting the target value as specific as possible
-const fooValue = watch("values.foo");
+const fooValue = mon("values.foo");
 
 // 👍🏻 It's OK, in most case the form's validation will be triggered less frequently
-const errors = watch("errors");
+const errors = mon("errors");
 // 👍🏻 But if a validation is triggered frequently, get the target error instead
-const fooError = watch("errors.foo");
+const fooError = mon("errors.foo");
 
 // 👍🏻 It's OK, they are triggered less frequently
-const [touched, dirty] = watch(["touched", "dirty"]);
+const [touched, dirty] = mon(["touched", "dirty"]);
 ```
 
 ### Missing Default Values?
 
-If we didn't initialize the default value of a field via the [defaultValues option](../api-reference/use-form#defaultvalues) of the `useForm`. The `watch` method will lose the value. Because the method is called before the field's initial render. For such cases, we can provide an alternative default value for the `watch` method to return as below:
+If we didn't initialize the default value of a field via the [defaultValues option](../api-reference/use-form#defaultvalues) of the `useForm`. The `mon` method will lose the value. Because the method is called before the field's initial render. For such cases, we can provide an alternative default value for the `mon` method to return as below:
 
 > 💡 If you need to refer to the status of a [conditional field](../examples/conditional-fields), we recommend to use React state instead.
 
@@ -106,12 +106,12 @@ If we didn't initialize the default value of a field via the [defaultValues opti
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     // Some options...
   });
 
-  cosnole.log(watch("values.foo")); // Returns undefined
-  cosnole.log(watch("values.foo", { defaultValues: { foo: "🍎" } })); // Returns "🍎"
+  cosnole.log(mon("values.foo")); // Returns undefined
+  cosnole.log(mon("values.foo", { defaultValues: { foo: "🍎" } })); // Returns "🍎"
 
   return (
     <form ref={form}>
@@ -125,26 +125,26 @@ const App = () => {
 
 ### Filter Untouched Field Errors
 
-Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `watch`'s `errorWithTouched` option (default is `false`).
+Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `mon`'s `errorWithTouched` option (default is `false`).
 
 > 💡 This feature filters any errors of the untouched fields. So when validating with the [runValidation](../api-reference/use-form#runvalidation), please ensure it's triggered after the field(s) is (are) touched.
 
 ```js
-const { watch } = useForm();
+const { mon } = useForm();
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: false } }
 // Returns { foo: "Required" }
-const errors = watch("errors");
+const errors = mon("errors");
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: false } }
 // Returns {}
-const errors = watch("errors", {
+const errors = mon("errors", {
   errorWithTouched: true,
 });
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: true } }
 // Returns { foo: "Required" }
-const errors = watch("errors", {
+const errors = mon("errors", {
   errorWithTouched: true,
 });
 ```
@@ -153,7 +153,7 @@ const errors = watch("errors", {
 
 ## Isolating Re-rendering
 
-Whenever a [selected value](#accessing-the-state) of the form state is updated, it will trigger re-renders. Re-renders are not bad but **slow re-renders** are (refer to the [article](https://kentcdodds.com/blog/fix-the-slow-render-before-you-fix-the-re-render#unnecessary-re-renders)). So, if you are building a complex form with large number of fields, you can isolate re-rendering at the component level via the [useFormState](../api-reference/use-form-state) hook for better performance. The hook has the similar API design to the `watch` method that maintain a consistent DX for us.
+Whenever a [selected value](#accessing-the-state) of the form state is updated, it will trigger re-renders. Re-renders are not bad but **slow re-renders** are (refer to the [article](https://kentcdodds.com/blog/fix-the-slow-render-before-you-fix-the-re-render#unnecessary-re-renders)). So, if you are building a complex form with large number of fields, you can isolate re-rendering at the component level via the [useFormState](../api-reference/use-form-state) hook for better performance. The hook has the similar API design to the `mon` method that maintain a consistent DX for us.
 
 [![Edit RCF - Isolating Re-rendering](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/intelligent-banach-uqxyx?fontsize=14&hidenavigation=1&theme=dark)
 

--- a/docs/getting-started/form-state.md
+++ b/docs/getting-started/form-state.md
@@ -31,36 +31,36 @@ Form state is an `object` containing the following properties:
 
 ## Using the Form State
 
-React Cool Form provides a powerful [select](../api-reference/use-form#select) method to help us avoid unnecessary re-renders when using the form state.
+React Cool Form provides a powerful [watch](../api-reference/use-form#watch) method to help us avoid unnecessary re-renders when using the form state.
 
 ### Accessing the State
 
-Due to the support of [complex structures](./complex-structures), the `select` method allows us to use [dot](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Dot_notation)-and-[bracket](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Bracket_notation) notation to get the form state.
+Due to the support of [complex structures](./complex-structures), the `watch` method allows us to use [dot](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Dot_notation)-and-[bracket](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Bracket_notation) notation to get the form state.
 
 ```js
-const { select } = useForm();
+const { watch } = useForm();
 
 // Returns { name: "Welly", orders: ["🍕", "🥤"] }
 // Re-renders the component when either "values.user" or "values.user.<property>" changes
-const user = select("values.user");
+const user = watch("values.user");
 
 // Returns "Welly", re-renders the component when "values.user.name" changes
-const name = select("values.user.name");
+const name = watch("values.user.name");
 
 // Returns "🍕", re-renders the component when "values.user.orders" changes
-const pizza = select("values.user.orders[0]");
+const pizza = watch("values.user.orders[0]");
 ```
 
 We can construct an array/object with multiple state-picks inside like the following example:
 
 ```js
-const { select } = useForm();
+const { watch } = useForm();
 
 // Array pick, re-renders the component when either "values.foo" or "values.bar" changes
-const [foo, bar] = select(["values.foo", "values.bar"]);
+const [foo, bar] = watch(["values.foo", "values.bar"]);
 
 // Object pick, re-renders the component when either "values.foo" or "values.bar" changes
-const { foo, bar } = select({ foo: "values.foo", bar: "values.bar" });
+const { foo, bar } = watch({ foo: "values.foo", bar: "values.bar" });
 ```
 
 From the code above, you can see we are getting the values of a specific target, it's kind of verbose. We can reduce it by the `target` option.
@@ -68,37 +68,37 @@ From the code above, you can see we are getting the values of a specific target,
 <!-- prettier-ignore-start -->
 ```js
 // Current state: { values: { foo: "🍎", bar: "🥝", baz: "🍋" } }
-const [foo, bar, baz] = select(["foo", "bar", "baz"], { target: "values" });
+const [foo, bar, baz] = watch(["foo", "bar", "baz"], { target: "values" });
 
 // Current state: { values: { nest: { foo: "🍎", bar: "🥝", baz: "🍋" } } }
-const [foo, bar, baz] = select(["foo", "bar", "baz"], { target: "values.nest" });
+const [foo, bar, baz] = watch(["foo", "bar", "baz"], { target: "values.nest" });
 ```
 <!-- prettier-ignore-end -->
 
 ### Best Practices
 
-Every time we access a value from the form state via the `select` method, it will listen the changes of the value and trigger re-renders only when necessary. Thus, there're some guidelines for us to use the form state. General speaking, when getting a value from an `object` state, **more specific more performant**.
+Every time we access a value from the form state via the `watch` method, it will listen the changes of the value and trigger re-renders only when necessary. Thus, there're some guidelines for us to use the form state. General speaking, when getting a value from an `object` state, **more specific more performant**.
 
 ```js
-const { select } = useForm();
+const { watch } = useForm();
 
-// 🙅🏻‍♀️ You can, but not recommended because it will cause the component to update on every value change
-const values = select("values");
-// 🙆🏻‍♀️ For the form's values, we always recommended getting the target value as specific as possible
-const fooValue = select("values.foo");
+// �🏻 You can, but not recommended because it will cause the component to update on every value change
+const values = watch("values");
+// �🏻 For the form's values, we always recommended getting the target value as specific as possible
+const fooValue = watch("values.foo");
 
-// 🙆🏻‍♀️ It's OK, in most case the form's validation will be triggered less frequently
-const errors = select("errors");
-// 🙆🏻‍♀️ But if a validation is triggered frequently, get the target error instead
-const fooError = select("errors.foo");
+// �🏻 It's OK, in most case the form's validation will be triggered less frequently
+const errors = watch("errors");
+// �🏻 But if a validation is triggered frequently, get the target error instead
+const fooError = watch("errors.foo");
 
-// 🙆🏻‍♀️ It's OK, they are triggered less frequently
-const [touched, dirty] = select(["touched", "dirty"]);
+// �🏻 It's OK, they are triggered less frequently
+const [touched, dirty] = watch(["touched", "dirty"]);
 ```
 
 ### Missing Default Values?
 
-If we didn't initialize the default value of a field via the [defaultValues option](../api-reference/use-form#defaultvalues) of the `useForm`. The `select` method will lose the value. Because the method is called before the field's initial render. For such cases, we can provide an alternative default value for the `select` method to return as below:
+If we didn't initialize the default value of a field via the [defaultValues option](../api-reference/use-form#defaultvalues) of the `useForm`. The `watch` method will lose the value. Because the method is called before the field's initial render. For such cases, we can provide an alternative default value for the `watch` method to return as below:
 
 > 💡 If you need to refer to the status of a [conditional field](../examples/conditional-fields), we recommend to use React state instead.
 
@@ -106,12 +106,12 @@ If we didn't initialize the default value of a field via the [defaultValues opti
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     // Some options...
   });
 
-  cosnole.log(select("values.foo")); // Returns undefined
-  cosnole.log(select("values.foo", { defaultValues: { foo: "🍎" } })); // Returns "🍎"
+  cosnole.log(watch("values.foo")); // Returns undefined
+  cosnole.log(watch("values.foo", { defaultValues: { foo: "🍎" } })); // Returns "🍎"
 
   return (
     <form ref={form}>
@@ -125,26 +125,26 @@ const App = () => {
 
 ### Filter Untouched Field Errors
 
-Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `select`'s `errorWithTouched` option (default is `false`).
+Error messages are dependent on the form's validation (i.e. the `errors` object). To avoid annoying the user by seeing an error message while typing, we can filter the errors of untouched fields by enable the `watch`'s `errorWithTouched` option (default is `false`).
 
 > 💡 This feature filters any errors of the untouched fields. So when validating with the [runValidation](../api-reference/use-form#runvalidation), please ensure it's triggered after the field(s) is (are) touched.
 
 ```js
-const { select } = useForm();
+const { watch } = useForm();
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: false } }
 // Returns { foo: "Required" }
-const errors = select("errors");
+const errors = watch("errors");
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: false } }
 // Returns {}
-const errors = select("errors", {
+const errors = watch("errors", {
   errorWithTouched: true,
 });
 
 // Current state: { errors: { foo: "Required" }, touched: { foo: true } }
 // Returns { foo: "Required" }
-const errors = select("errors", {
+const errors = watch("errors", {
   errorWithTouched: true,
 });
 ```
@@ -153,7 +153,7 @@ const errors = select("errors", {
 
 ## Isolating Re-rendering
 
-Whenever a [selected value](#accessing-the-state) of the form state is updated, it will trigger re-renders. Re-renders are not bad but **slow re-renders** are (refer to the [article](https://kentcdodds.com/blog/fix-the-slow-render-before-you-fix-the-re-render#unnecessary-re-renders)). So, if you are building a complex form with large number of fields, you can isolate re-rendering at the component level via the [useFormState](../api-reference/use-form-state) hook for better performance. The hook has the similar API design to the `select` method that maintain a consistent DX for us.
+Whenever a [selected value](#accessing-the-state) of the form state is updated, it will trigger re-renders. Re-renders are not bad but **slow re-renders** are (refer to the [article](https://kentcdodds.com/blog/fix-the-slow-render-before-you-fix-the-re-render#unnecessary-re-renders)). So, if you are building a complex form with large number of fields, you can isolate re-rendering at the component level via the [useFormState](../api-reference/use-form-state) hook for better performance. The hook has the similar API design to the `watch` method that maintain a consistent DX for us.
 
 [![Edit RCF - Isolating Re-rendering](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/intelligent-banach-uqxyx?fontsize=14&hidenavigation=1&theme=dark)
 

--- a/docs/getting-started/form-submission.md
+++ b/docs/getting-started/form-submission.md
@@ -28,12 +28,12 @@ const errorHandler = (errors, options, e) => {
 };
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { username: "", email: "" },
     onSubmit: submitHandler, // The event is triggered once the form is valid
     onError: errorHandler, // The event is triggered once the form is invalid (optional)
   });
-  const isSubmitting = watch("isSubmitting");
+  const isSubmitting = mon("isSubmitting");
 
   return (
     <form ref={form} noValidate>
@@ -87,12 +87,12 @@ For some reasons (e.g. design requirement, auto-retry etc.), we might need to tr
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, watch, submit } = useForm({
+  const { form, mon, submit } = useForm({
     defaultValues: { username: "", email: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
-  const isSubmitting = watch("isSubmitting");
+  const isSubmitting = mon("isSubmitting");
 
   const handleSubmit = () => {
     submit();

--- a/docs/getting-started/form-submission.md
+++ b/docs/getting-started/form-submission.md
@@ -28,12 +28,12 @@ const errorHandler = (errors, options, e) => {
 };
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     defaultValues: { username: "", email: "" },
-    onSubmit: submitHandler, // 🙆🏻‍♀️ The event is triggered once the form is valid
-    onError: errorHandler, // 🙅🏻‍♀️ The event is triggered once the form is invalid (optional)
+    onSubmit: submitHandler, // The event is triggered once the form is valid
+    onError: errorHandler, // The event is triggered once the form is invalid (optional)
   });
-  const isSubmitting = select("isSubmitting");
+  const isSubmitting = watch("isSubmitting");
 
   return (
     <form ref={form} noValidate>
@@ -87,12 +87,12 @@ For some reasons (e.g. design requirement, auto-retry etc.), we might need to tr
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, select, submit } = useForm({
+  const { form, watch, submit } = useForm({
     defaultValues: { username: "", email: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
-  const isSubmitting = select("isSubmitting");
+  const isSubmitting = watch("isSubmitting");
 
   const handleSubmit = () => {
     submit();

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -57,7 +57,7 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     // (Strongly advise) Provide the default values just like we use React state
     defaultValues: { username: "", email: "", password: "" },
     // The event only triggered when the form is valid
@@ -65,7 +65,7 @@ const App = () => {
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = mon("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -57,7 +57,7 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     // (Strongly advise) Provide the default values just like we use React state
     defaultValues: { username: "", email: "", password: "" },
     // The event only triggered when the form is valid
@@ -65,7 +65,7 @@ const App = () => {
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = select("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>

--- a/docs/getting-started/integration-an-existing-form.md
+++ b/docs/getting-started/integration-an-existing-form.md
@@ -102,11 +102,11 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, watch, submit } = useForm({
+  const { form, mon, submit } = useForm({
     defaultValues: { email: "", password: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = watch("errors", { errorWithTouched: true });
+  const errors = mon("errors", { errorWithTouched: true });
 
   return (
     <div ref={form}>

--- a/docs/getting-started/integration-an-existing-form.md
+++ b/docs/getting-started/integration-an-existing-form.md
@@ -102,11 +102,11 @@ const Field = ({ label, id, error, ...rest }) => (
 );
 
 const App = () => {
-  const { form, select, submit } = useForm({
+  const { form, watch, submit } = useForm({
     defaultValues: { email: "", password: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
-  const errors = select("errors", { errorWithTouched: true });
+  const errors = watch("errors", { errorWithTouched: true });
 
   return (
     <div ref={form}>

--- a/docs/getting-started/typescript-support.md
+++ b/docs/getting-started/typescript-support.md
@@ -65,7 +65,7 @@ enum FieldNames {
   "fieldName.a[0].b" = "fieldName.a[0].b",
 }
 
-<input name={FieldNames["fieldName.a[0].c"]} />; // 🙅🏻‍♀️ Property "fieldName.a[0].c" does not exist on type "typeof FieldNames". Did you mean "fieldName.a[0].b"?
+<input name={FieldNames["fieldName.a[0].c"]} />; // 👎🏻 Property "fieldName.a[0].c" does not exist on type "typeof FieldNames". Did you mean "fieldName.a[0].b"?
 ```
 
 🧐 You can dig more useful [types](https://github.com/wellyshen/react-cool-form/blob/master/src/types/react-cool-form.d.ts) of this library to build a strongly typed form.

--- a/docs/getting-started/validation-guide.md
+++ b/docs/getting-started/validation-guide.md
@@ -77,14 +77,14 @@ const validate = async (values) => {
 };
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { username: "", email: "" },
     validate,
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("Form is validating: ", watch("isValidating"));
+  console.log("Form is validating: ", mon("isValidating"));
 
   return (
     <form ref={form} noValidate>
@@ -170,13 +170,13 @@ const validateUsername = async (value, values /* Form values */) => {
 };
 
 const App = () => {
-  const { form, field, watch } = useForm({
+  const { form, field, mon } = useForm({
     defaultValues: { username: "", email: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("Form is validating: ", watch("isValidating"));
+  console.log("Form is validating: ", mon("isValidating"));
 
   return (
     <form ref={form} noValidate>
@@ -288,7 +288,7 @@ When validating with mixed ways, the results are deeply merged according to the 
 
 ## Displaying Error Messages
 
-All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [watch](../api-reference/use-form#watch) method. The method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filter-untouched-field-errors)).
+All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [mon](../api-reference/use-form#mon) method. The method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filter-untouched-field-errors)).
 
 [![Edit RCF - Quick start](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/rcf-quick-start-j8p1l?fontsize=14&hidenavigation=1&theme=dark)
 
@@ -296,13 +296,13 @@ All errors are stored in the [formState.errors](./form-state#about-the-form-stat
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { username: "", email: "", password: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = mon("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>
@@ -324,11 +324,11 @@ The built-in validation is **turned on** by default. Which provides two forms of
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, watch } = useForm({
+  const { form, mon } = useForm({
     builtInValidationMode: "message" | "state" | false, // Default is "message"
     // More options...
   });
-  const errors = watch("errors");
+  const errors = mon("errors");
 
   console.log("Message mode: ", errors); // Returns a localized message that describes the validation constraints that the field does not satisfy (if any)
   console.log("State mode: ", errors); // Returns the "key" of the invalid property of the ValidityState (if any)

--- a/docs/getting-started/validation-guide.md
+++ b/docs/getting-started/validation-guide.md
@@ -77,14 +77,14 @@ const validate = async (values) => {
 };
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     defaultValues: { username: "", email: "" },
     validate,
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("Form is validating: ", select("isValidating"));
+  console.log("Form is validating: ", watch("isValidating"));
 
   return (
     <form ref={form} noValidate>
@@ -170,13 +170,13 @@ const validateUsername = async (value, values /* Form values */) => {
 };
 
 const App = () => {
-  const { form, field, select } = useForm({
+  const { form, field, watch } = useForm({
     defaultValues: { username: "", email: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("Form is validating: ", select("isValidating"));
+  console.log("Form is validating: ", watch("isValidating"));
 
   return (
     <form ref={form} noValidate>
@@ -288,7 +288,7 @@ When validating with mixed ways, the results are deeply merged according to the 
 
 ## Displaying Error Messages
 
-All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [select](../api-reference/use-form#select) method. The method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filter-untouched-field-errors)).
+All errors are stored in the [formState.errors](./form-state#about-the-form-state), we can display error messages by accessing the `errors` object via the [watch](../api-reference/use-form#watch) method. The method provides an `errorWithTouched` option to help us filtering the errors of untouched fields, which is designed based on the [Errors in Forms design guideline](https://www.nngroup.com/articles/errors-forms-design-guidelines) (No.7). You can enable the feature by setting the option to `true` (see [related doc](./form-state#filter-untouched-field-errors)).
 
 [![Edit RCF - Quick start](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/rcf-quick-start-j8p1l?fontsize=14&hidenavigation=1&theme=dark)
 
@@ -296,13 +296,13 @@ All errors are stored in the [formState.errors](./form-state#about-the-form-stat
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     defaultValues: { username: "", email: "", password: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
   });
   // We can enable the "errorWithTouched" option to filter the error of an un-blurred field
   // Which helps the user focus on typing without being annoyed by the error message
-  const errors = select("errors", { errorWithTouched: true }); // Default is "false"
+  const errors = watch("errors", { errorWithTouched: true }); // Default is "false"
 
   return (
     <form ref={form} noValidate>
@@ -324,11 +324,11 @@ The built-in validation is **turned on** by default. Which provides two forms of
 import { useForm } from "react-cool-form";
 
 const App = () => {
-  const { form, select } = useForm({
+  const { form, watch } = useForm({
     builtInValidationMode: "message" | "state" | false, // Default is "message"
     // More options...
   });
-  const errors = select("errors");
+  const errors = watch("errors");
 
   console.log("Message mode: ", errors); // Returns a localized message that describes the validation constraints that the field does not satisfy (if any)
   console.log("State mode: ", errors); // Returns the "key" of the invalid property of the ValidityState (if any)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -194,7 +194,7 @@ export interface GetFormState<V = any> {
   ): any;
 }
 
-export interface Select<V> {
+export interface Watch<V> {
   (
     path: Path,
     options?: { target?: string; defaultValues?: V; errorWithTouched?: boolean }
@@ -274,7 +274,7 @@ export type FormConfig<V = any> = Partial<{
 export interface FormMethods<V = any> {
   form: RegisterForm;
   field: RegisterField<V>;
-  select: Select<V>;
+  watch: Watch<V>;
   getState: GetState;
   setValue: SetValue;
   setTouched: SetTouched;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -274,7 +274,7 @@ export type FormConfig<V = any> = Partial<{
 export interface FormMethods<V = any> {
   form: RegisterForm;
   field: RegisterField<V>;
-  watch: Watch<V>;
+  mon: Watch<V>;
   getState: GetState;
   setValue: SetValue;
   setTouched: SetTouched;

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -21,7 +21,7 @@ declare module "react-cool-form" {
     submit: Submit<V>;
   }
 
-  interface Select<V> {
+  interface Watch<V> {
     (
       path: string | string[] | Map<string>,
       options?: {
@@ -187,7 +187,7 @@ declare module "react-cool-form" {
   export interface FormMethods<V extends FormValues = FormValues> {
     form: RegisterForm;
     field: RegisterField<V>;
-    select: Select<V>;
+    watch: Watch<V>;
     getState: GetState;
     setValue: SetValue;
     setTouched: SetTouched;

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -187,7 +187,7 @@ declare module "react-cool-form" {
   export interface FormMethods<V extends FormValues = FormValues> {
     form: RegisterForm;
     field: RegisterField<V>;
-    watch: Watch<V>;
+    mon: Watch<V>;
     getState: GetState;
     setValue: SetValue;
     setTouched: SetTouched;

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -134,17 +134,17 @@ describe("useForm", () => {
       expect(console.warn).not.toHaveBeenCalled();
     });
 
-    it('should warn select "values" alone', () => {
-      const { select } = renderHelper();
-      select("values");
+    it('should warn watch "values" alone', () => {
+      const { watch } = renderHelper();
+      watch("values");
       expect(console.warn).toHaveBeenCalledWith(
-        '💡 react-cool-form > select: Getting "values" alone might cause unnecessary re-renders. If you know what you\'re doing, please ignore this warning. See: https://react-cool-form.netlify.app/docs/getting-started/form-state#best-practices'
+        '💡 react-cool-form > watch: Getting "values" alone might cause unnecessary re-renders. If you know what you\'re doing, please ignore this warning. See: https://react-cool-form.netlify.app/docs/getting-started/form-state#best-practices'
       );
     });
 
-    it('should not warn select "values" alone', () => {
-      const { select } = renderHelper();
-      select("values.foo");
+    it('should not warn watch "values" alone', () => {
+      const { watch } = renderHelper();
+      watch("values.foo");
       expect(console.warn).not.toHaveBeenCalled();
     });
 
@@ -221,7 +221,7 @@ describe("useForm", () => {
     expect(methods).toEqual({
       form: expect.any(Function),
       field: expect.any(Function),
-      select: expect.any(Function),
+      watch: expect.any(Function),
       getState: expect.any(Function),
       setValue: expect.any(Function),
       setTouched: expect.any(Function),
@@ -1407,50 +1407,50 @@ describe("useForm", () => {
     });
   });
 
-  describe("select", () => {
+  describe("watch", () => {
     const { values, isValid } = { ...initialState, values: { foo: "🍎" } };
 
     it('should return undefined if "path" isn\'t set', () => {
-      const { select } = renderHelper();
+      const { watch } = renderHelper();
       // @ts-expect-error
-      expect(select()).toBeUndefined();
+      expect(watch()).toBeUndefined();
     });
 
     it("should get default value correctly", () => {
       const formValue = { foo: null };
       const selectValue = { foo: "🍎" };
-      let { select } = renderHelper({ defaultValues: formValue });
-      expect(select("values.foo")).toBe(formValue.foo);
+      let { watch } = renderHelper({ defaultValues: formValue });
+      expect(watch("values.foo")).toBe(formValue.foo);
 
-      expect(select("values.foo", { defaultValues: selectValue })).toBe(
+      expect(watch("values.foo", { defaultValues: selectValue })).toBe(
         formValue.foo
       );
 
-      select = renderHelper().select;
-      expect(select("values.foo", { defaultValues: selectValue })).toBe(
+      watch = renderHelper().watch;
+      expect(watch("values.foo", { defaultValues: selectValue })).toBe(
         selectValue.foo
       );
 
-      expect(select("values.foo")).toBeUndefined();
+      expect(watch("values.foo")).toBeUndefined();
     });
 
     it.todo("should get default value correctly with conditional field");
 
     it("should get state with correct format", () => {
-      const { select } = renderHelper({ defaultValues: values });
+      const { watch } = renderHelper({ defaultValues: values });
 
-      expect(select("values")).toEqual(values);
-      expect(select("values.foo")).toBe(values.foo);
-      expect(select("isValid")).toBe(isValid);
+      expect(watch("values")).toEqual(values);
+      expect(watch("values.foo")).toBe(values.foo);
+      expect(watch("isValid")).toBe(isValid);
 
-      expect(select(["values", "values.foo", "isValid"])).toEqual([
+      expect(watch(["values", "values.foo", "isValid"])).toEqual([
         values,
         values.foo,
         isValid,
       ]);
 
       expect(
-        select({
+        watch({
           values: "values",
           foo: "values.foo",
           isValid: "isValid",
@@ -1459,42 +1459,40 @@ describe("useForm", () => {
     });
 
     it("should get state with specific target", () => {
-      const { select } = renderHelper({ defaultValues: values });
+      const { watch } = renderHelper({ defaultValues: values });
       const option = { target: "values" };
       const { foo } = values;
-      expect(select("foo", option)).toBe(foo);
-      expect(select(["foo"], option)).toEqual([foo]);
-      expect(select({ foo: "foo" }, option)).toEqual({ foo });
+      expect(watch("foo", option)).toBe(foo);
+      expect(watch(["foo"], option)).toEqual([foo]);
+      expect(watch({ foo: "foo" }, option)).toEqual({ foo });
     });
 
     it("should get error with touched", async () => {
-      const { select } = renderHelper({
+      const { watch } = renderHelper({
         children: <input data-testid="foo" name="foo" required />,
       });
       const foo = getByTestId("foo");
 
       fireEvent.input(foo, { target: { value: "" } });
       await waitFor(() => {
-        expect(select("errors.foo")).not.toBeUndefined();
-        expect(
-          select("errors.foo", { errorWithTouched: true })
-        ).toBeUndefined();
+        expect(watch("errors.foo")).not.toBeUndefined();
+        expect(watch("errors.foo", { errorWithTouched: true })).toBeUndefined();
       });
 
       fireEvent.focusOut(foo);
       await waitFor(() => {
         expect(
-          select("errors.foo", { errorWithTouched: true })
+          watch("errors.foo", { errorWithTouched: true })
         ).not.toBeUndefined();
       });
     });
 
     it("should trigger re-rendering", () => {
-      const { select } = renderHelper({
+      const { watch } = renderHelper({
         onRender,
         children: <input data-testid="foo" name="foo" />,
       });
-      select("values.foo");
+      watch("values.foo");
       fireEvent.input(getByTestId("foo"));
       expect(onRender).toHaveBeenCalledTimes(2);
     });

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -134,17 +134,17 @@ describe("useForm", () => {
       expect(console.warn).not.toHaveBeenCalled();
     });
 
-    it('should warn watch "values" alone', () => {
-      const { watch } = renderHelper();
-      watch("values");
+    it('should warn mon "values" alone', () => {
+      const { mon } = renderHelper();
+      mon("values");
       expect(console.warn).toHaveBeenCalledWith(
-        '💡 react-cool-form > watch: Getting "values" alone might cause unnecessary re-renders. If you know what you\'re doing, please ignore this warning. See: https://react-cool-form.netlify.app/docs/getting-started/form-state#best-practices'
+        '💡 react-cool-form > mon: Getting "values" alone might cause unnecessary re-renders. If you know what you\'re doing, please ignore this warning. See: https://react-cool-form.netlify.app/docs/getting-started/form-state#best-practices'
       );
     });
 
-    it('should not warn watch "values" alone', () => {
-      const { watch } = renderHelper();
-      watch("values.foo");
+    it('should not warn mon "values" alone', () => {
+      const { mon } = renderHelper();
+      mon("values.foo");
       expect(console.warn).not.toHaveBeenCalled();
     });
 
@@ -221,7 +221,7 @@ describe("useForm", () => {
     expect(methods).toEqual({
       form: expect.any(Function),
       field: expect.any(Function),
-      watch: expect.any(Function),
+      mon: expect.any(Function),
       getState: expect.any(Function),
       setValue: expect.any(Function),
       setTouched: expect.any(Function),
@@ -1407,50 +1407,50 @@ describe("useForm", () => {
     });
   });
 
-  describe("watch", () => {
+  describe("mon", () => {
     const { values, isValid } = { ...initialState, values: { foo: "🍎" } };
 
     it('should return undefined if "path" isn\'t set', () => {
-      const { watch } = renderHelper();
+      const { mon } = renderHelper();
       // @ts-expect-error
-      expect(watch()).toBeUndefined();
+      expect(mon()).toBeUndefined();
     });
 
     it("should get default value correctly", () => {
       const formValue = { foo: null };
       const selectValue = { foo: "🍎" };
-      let { watch } = renderHelper({ defaultValues: formValue });
-      expect(watch("values.foo")).toBe(formValue.foo);
+      let { mon } = renderHelper({ defaultValues: formValue });
+      expect(mon("values.foo")).toBe(formValue.foo);
 
-      expect(watch("values.foo", { defaultValues: selectValue })).toBe(
+      expect(mon("values.foo", { defaultValues: selectValue })).toBe(
         formValue.foo
       );
 
-      watch = renderHelper().watch;
-      expect(watch("values.foo", { defaultValues: selectValue })).toBe(
+      mon = renderHelper().mon;
+      expect(mon("values.foo", { defaultValues: selectValue })).toBe(
         selectValue.foo
       );
 
-      expect(watch("values.foo")).toBeUndefined();
+      expect(mon("values.foo")).toBeUndefined();
     });
 
     it.todo("should get default value correctly with conditional field");
 
     it("should get state with correct format", () => {
-      const { watch } = renderHelper({ defaultValues: values });
+      const { mon } = renderHelper({ defaultValues: values });
 
-      expect(watch("values")).toEqual(values);
-      expect(watch("values.foo")).toBe(values.foo);
-      expect(watch("isValid")).toBe(isValid);
+      expect(mon("values")).toEqual(values);
+      expect(mon("values.foo")).toBe(values.foo);
+      expect(mon("isValid")).toBe(isValid);
 
-      expect(watch(["values", "values.foo", "isValid"])).toEqual([
+      expect(mon(["values", "values.foo", "isValid"])).toEqual([
         values,
         values.foo,
         isValid,
       ]);
 
       expect(
-        watch({
+        mon({
           values: "values",
           foo: "values.foo",
           isValid: "isValid",
@@ -1459,40 +1459,40 @@ describe("useForm", () => {
     });
 
     it("should get state with specific target", () => {
-      const { watch } = renderHelper({ defaultValues: values });
+      const { mon } = renderHelper({ defaultValues: values });
       const option = { target: "values" };
       const { foo } = values;
-      expect(watch("foo", option)).toBe(foo);
-      expect(watch(["foo"], option)).toEqual([foo]);
-      expect(watch({ foo: "foo" }, option)).toEqual({ foo });
+      expect(mon("foo", option)).toBe(foo);
+      expect(mon(["foo"], option)).toEqual([foo]);
+      expect(mon({ foo: "foo" }, option)).toEqual({ foo });
     });
 
     it("should get error with touched", async () => {
-      const { watch } = renderHelper({
+      const { mon } = renderHelper({
         children: <input data-testid="foo" name="foo" required />,
       });
       const foo = getByTestId("foo");
 
       fireEvent.input(foo, { target: { value: "" } });
       await waitFor(() => {
-        expect(watch("errors.foo")).not.toBeUndefined();
-        expect(watch("errors.foo", { errorWithTouched: true })).toBeUndefined();
+        expect(mon("errors.foo")).not.toBeUndefined();
+        expect(mon("errors.foo", { errorWithTouched: true })).toBeUndefined();
       });
 
       fireEvent.focusOut(foo);
       await waitFor(() => {
         expect(
-          watch("errors.foo", { errorWithTouched: true })
+          mon("errors.foo", { errorWithTouched: true })
         ).not.toBeUndefined();
       });
     });
 
     it("should trigger re-rendering", () => {
-      const { watch } = renderHelper({
+      const { mon } = renderHelper({
         onRender,
         children: <input data-testid="foo" name="foo" />,
       });
-      watch("values.foo");
+      mon("values.foo");
       fireEvent.input(getByTestId("foo"));
       expect(onRender).toHaveBeenCalledTimes(2);
     });

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -27,7 +27,6 @@ import {
   RemoveField,
   Reset,
   RunValidation,
-  Select,
   SetDefaultValue,
   SetDirty,
   SetError,
@@ -35,6 +34,7 @@ import {
   SetTouchedMaybeValidate,
   SetValue,
   Submit,
+  Watch,
 } from "./types";
 import { useLatest, useState } from "./hooks";
 import {
@@ -320,7 +320,7 @@ export default <V extends FormValues = FormValues>({
         target,
         errorWithTouched,
         defaultValues: dfValues = {},
-        methodName = "select",
+        methodName = "watch",
         callback,
       }
     ) => {
@@ -390,7 +390,7 @@ export default <V extends FormValues = FormValues>({
     [stateRef]
   );
 
-  const select = useCallback<Select<V>>(
+  const watch = useCallback<Watch<V>>(
     (path, { target, errorWithTouched, defaultValues: dfValues } = {}) =>
       getFormState(path, {
         target,
@@ -948,7 +948,7 @@ export default <V extends FormValues = FormValues>({
     unsubscribeObserver,
     form: registerForm,
     field: registerField,
-    select,
+    watch,
     getState,
     setValue,
     setTouched,
@@ -980,7 +980,7 @@ export default <V extends FormValues = FormValues>({
   return {
     form: registerForm,
     field: registerField,
-    select,
+    watch,
     getState,
     setValue,
     setTouched,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -320,7 +320,7 @@ export default <V extends FormValues = FormValues>({
         target,
         errorWithTouched,
         defaultValues: dfValues = {},
-        methodName = "watch",
+        methodName = "mon",
         callback,
       }
     ) => {
@@ -390,7 +390,7 @@ export default <V extends FormValues = FormValues>({
     [stateRef]
   );
 
-  const watch = useCallback<Watch<V>>(
+  const mon = useCallback<Watch<V>>(
     (path, { target, errorWithTouched, defaultValues: dfValues } = {}) =>
       getFormState(path, {
         target,
@@ -948,7 +948,7 @@ export default <V extends FormValues = FormValues>({
     unsubscribeObserver,
     form: registerForm,
     field: registerField,
-    watch,
+    mon,
     getState,
     setValue,
     setTouched,
@@ -980,7 +980,7 @@ export default <V extends FormValues = FormValues>({
   return {
     form: registerForm,
     field: registerField,
-    watch,
+    mon,
     getState,
     setValue,
     setTouched,

--- a/src/useFormMethods.test.tsx
+++ b/src/useFormMethods.test.tsx
@@ -43,7 +43,7 @@ describe("useFormMethods", () => {
     expect(methods).toEqual({
       form: expect.any(Function),
       field: expect.any(Function),
-      watch: expect.any(Function),
+      mon: expect.any(Function),
       getState: expect.any(Function),
       setValue: expect.any(Function),
       setTouched: expect.any(Function),

--- a/src/useFormMethods.test.tsx
+++ b/src/useFormMethods.test.tsx
@@ -43,7 +43,7 @@ describe("useFormMethods", () => {
     expect(methods).toEqual({
       form: expect.any(Function),
       field: expect.any(Function),
-      select: expect.any(Function),
+      watch: expect.any(Function),
       getState: expect.any(Function),
       setValue: expect.any(Function),
       setTouched: expect.any(Function),

--- a/src/useFormMethods.ts
+++ b/src/useFormMethods.ts
@@ -15,7 +15,7 @@ export default <V extends FormValues = FormValues>(
   const {
     form,
     field,
-    watch,
+    mon,
     getState,
     setValue,
     setTouched,
@@ -30,7 +30,7 @@ export default <V extends FormValues = FormValues>(
   return {
     form,
     field,
-    watch,
+    mon,
     getState,
     setValue,
     setTouched,

--- a/src/useFormMethods.ts
+++ b/src/useFormMethods.ts
@@ -15,7 +15,7 @@ export default <V extends FormValues = FormValues>(
   const {
     form,
     field,
-    select,
+    watch,
     getState,
     setValue,
     setTouched,
@@ -30,7 +30,7 @@ export default <V extends FormValues = FormValues>(
   return {
     form,
     field,
-    select,
+    watch,
     getState,
     setValue,
     setTouched,

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -64,7 +64,7 @@ describe("useFormState", () => {
     );
   });
 
-  it('should warn watch "values" alone', () => {
+  it('should warn mon "values" alone', () => {
     console.warn = jest.fn();
     renderHelper({ path: "values" });
     expect(console.warn).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe("useFormState", () => {
     );
   });
 
-  it('should not warn watch "values" alone', () => {
+  it('should not warn mon "values" alone', () => {
     console.warn = jest.fn();
     renderHelper({ path: "values.foo" });
     expect(console.warn).not.toHaveBeenCalled();

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -64,7 +64,7 @@ describe("useFormState", () => {
     );
   });
 
-  it('should warn select "values" alone', () => {
+  it('should warn watch "values" alone', () => {
     console.warn = jest.fn();
     renderHelper({ path: "values" });
     expect(console.warn).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe("useFormState", () => {
     );
   });
 
-  it('should not warn select "values" alone', () => {
+  it('should not warn watch "values" alone', () => {
     console.warn = jest.fn();
     renderHelper({ path: "values.foo" });
     expect(console.warn).not.toHaveBeenCalled();


### PR DESCRIPTION
- Rename `select` method to `mon` (a.k.a monitor)