### PR TITLE
Fix(useForm): when running field-level validation with nested field(s), the last field will overrides the error results

### DIFF
--- a/.changeset/hungry-pants-play.md
+++ b/.changeset/hungry-pants-play.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useForm): when running field validation with nested field(s), error results will be overrided by the last field

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1076,6 +1076,27 @@ describe("useForm", () => {
       }
     );
 
+    it("should run field-level validation with nested fields", async () => {
+      const errors = { foo: { a: "Required", b: "Required" } };
+      renderHelper({
+        onError,
+        children: ({ field }: Methods) => (
+          <>
+            <input
+              name="foo.a"
+              ref={field((val: string) => (!val.length ? errors.foo.a : false))}
+            />
+            <input
+              name="foo.b"
+              ref={field((val: string) => (!val.length ? errors.foo.b : false))}
+            />
+          </>
+        ),
+      });
+      fireEvent.submit(getByTestId("form"));
+      await waitFor(() => expect(onError).toHaveBeenCalledWith(errors));
+    });
+
     it("should run field-level validation with dependent fields", async () => {
       const errors = { foo: "Bar is required" };
       renderHelper({

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -487,7 +487,7 @@ export default <V extends FormValues = FormValues>({
 
     return Promise.all(promises).then((errors) =>
       Object.keys(fieldValidatorsRef.current).reduce((acc, cur, idx) => {
-        acc = { ...acc, ...(errors[idx] ? set({}, cur, errors[idx]) : {}) };
+        acc = { ...acc, ...(errors[idx] ? set(acc, cur, errors[idx]) : {}) };
         return acc;
       }, {})
     );


### PR DESCRIPTION
- Fix(useForm): when running field-level validation with nested field(s), the last field will overrides the error results