### PR TITLE
Fix(useFormState): "errorWithTouched" option not works in some cases

### DIFF
--- a/.changeset/big-radios-sin.md
+++ b/.changeset/big-radios-sin.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useFormState): `errorWithTouched` option not works in some cases

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -1,32 +1,21 @@
 /* eslint-disable no-console */
 
-import { useForm, useFieldArray } from "react-cool-form";
+import { useForm, useFormState } from "react-cool-form";
 
 export default () => {
-  const { form, focus } = useForm({
-    defaultValues: { foo: [{ a: "test-1", b: "test-1" }] },
+  const { form } = useForm({
+    defaultValues: { foo: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
+    onError: (errors) => console.log("onError: ", errors),
   });
-  const [fields, { push }] = useFieldArray("foo");
+
+  const errors = useFormState("errors", { errorWithTouched: true });
 
   return (
-    <form ref={form}>
-      {fields.map((name) => (
-        <div key={name}>
-          <input name={`${name}.a`} />
-          <input name={`${name}.b`} />
-        </div>
-      ))}
-      <button
-        type="button"
-        onClick={() => {
-          push({ a: "test-2", b: "test-2" });
-          focus(`foo[${fields.length}]`, 0);
-          // focus(`foo[${fields.length}].b`, 300);
-        }}
-      >
-        Push
-      </button>
+    <form ref={form} noValidate>
+      <input name="foo" type="email" required />
+      {errors.foo && <p>{errors.foo}</p>}
+      <input type="submit" />
     </form>
   );
 };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -549,13 +549,7 @@ export default <V extends FormValues = FormValues>({
             return !isUndefined(v) ? v : get(dfValues, p);
           }
 
-          if (
-            !errorWithTouched ||
-            !p.startsWith("errors") ||
-            !v ||
-            isEmptyObject(v)
-          )
-            return v;
+          if (!errorWithTouched || !p.startsWith("errors")) return v;
 
           p = p.replace("errors", "touched");
           usedState[p] = true;

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -155,8 +155,7 @@ describe("useFormState", () => {
   });
 
   it("should get error with touched", () => {
-    const path = "errors.foo";
-    const args = { path, isError: true };
+    const args = { path: "errors.foo", isError: true };
 
     expect(renderHelper(args)).not.toBeUndefined();
 

--- a/src/utils/filterErrors.test.ts
+++ b/src/utils/filterErrors.test.ts
@@ -2,6 +2,11 @@ import filterErrors from "./filterErrors";
 
 describe("filterErrors", () => {
   it("should work correctly", () => {
+    expect(filterErrors(undefined, false)).toBeUndefined();
+    expect(filterErrors(undefined, false)).toBeUndefined();
+    expect(filterErrors({}, false)).toEqual({});
+    expect(filterErrors("🍎", false)).toBeUndefined();
+    expect(filterErrors("🍎", true)).toBe("🍎");
     expect(filterErrors({ foo: "🍎" }, { foo: true })).toEqual({ foo: "🍎" });
     expect(filterErrors({ foo: "🍎" }, {})).toEqual({});
     const foo = new Date();


### PR DESCRIPTION
- Fix(useFormState): `errorWithTouched` option not works in some cases