### PR TITLE
Fix(useForm): do not warn missing name when excluding a field via `data-rcf-exclude`

### DIFF
--- a/.changeset/tame-avocados-yawn.md
+++ b/.changeset/tame-avocados-yawn.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useForm): do not warn missing name when excluding a field via data attribute

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -3,33 +3,15 @@
 import { useForm } from "react-cool-form";
 
 export default () => {
-  const { form, runValidation, mon, field } = useForm({
+  const { form } = useForm({
     defaultValues: { foo: "" },
-    // validate: async () => {
-    //   // eslint-disable-next-line compat/compat
-    //   await new Promise((resolve) => setTimeout(resolve, 1000));
-    //   return { foo: "Required" };
-    // },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("LOG ===> ", mon("errors"));
-
   return (
     <form ref={form} noValidate>
-      <input
-        name="foo"
-        ref={field(async () => {
-          // eslint-disable-next-line compat/compat
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-          return false;
-          // return "Required";
-        })}
-      />
-      <button type="button" onClick={() => runValidation(null, true)}>
-        Validate
-      </button>
+      <input data-rcf-exclude />
     </form>
   );
 };

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -126,12 +126,15 @@ describe("useForm", () => {
     });
 
     it("should not warn for a missing name field", () => {
-      renderHelper({ children: <input data-testid="foo" name="foo" /> });
+      renderHelper({ children: <input name="foo" /> });
       expect(console.warn).not.toHaveBeenCalled();
     });
 
     it("should not warn for a missing name field when it's excluded", () => {
-      renderHelper({ children: <input data-rcf-exclude /> });
+      renderHelper({ children: <input data-testid="foo" data-rcf-exclude /> });
+      expect(console.warn).not.toHaveBeenCalled();
+
+      fireEvent.input(getByTestId("foo"), { target: { value: "🍎" } });
       expect(console.warn).not.toHaveBeenCalled();
     });
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -882,9 +882,9 @@ export default <V extends FormValues = FormValues>({
       setNodesOrValues(initialStateRef.current.values);
 
       handlersRef.current.change = ({ target }: Event) => {
-        const { name } = target as FieldElement;
+        const { dataset, name } = target as FieldElement;
 
-        if (!name) {
+        if (!dataset.rcfExclude && !name) {
           warn('💡 react-cool-form > field: Missing "name" attribute.');
           return;
         }


### PR DESCRIPTION
- Fix(useForm): do not warn missing name when excluding a field via `data-rcf-exclude`