### PR TITLE
Refactor(useForm): deprecate the `shouldFocus` parameter of `runValidation` API

### DIFF
--- a/.changeset/cold-dolphins-sneeze.md
+++ b/.changeset/cold-dolphins-sneeze.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Refactor(useForm): deprecate the `shouldFocus` parameter of `runValidation` API

--- a/app/src/Playground/index.tsx
+++ b/app/src/Playground/index.tsx
@@ -2,18 +2,33 @@
 
 import { useForm, useFormState } from "react-cool-form";
 
+const Field = ({ name, error, ...rest }: any) => {
+  const errors = useFormState("errors", { errorWithTouched: true });
+
+  return (
+    <>
+      <input name={name} {...rest} />
+      {errors && <p>{errors[name]}</p>}
+    </>
+  );
+};
+
 export default () => {
-  const { form } = useForm({
+  const { form, mon } = useForm({
     defaultValues: { foo: "" },
     onSubmit: (values) => console.log("onSubmit: ", values),
     onError: (errors) => console.log("onError: ", errors),
   });
 
-  console.log("LOG ===> ", useFormState("foo"));
+  // const errors = mon("errors", { errorWithTouched: true });
+  // const errors = useFormState("errors", { errorWithTouched: true });
 
   return (
     <form ref={form} noValidate>
-      <input name="foo" />
+      <Field name="foo" required />
+      {/* <input name="foo" required />
+      {errors.foo && <p>{errors.foo}</p>} */}
+      <input type="submit" />
     </form>
   );
 };

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -413,12 +413,11 @@ clearErrors(["foo.bar", "foo.baz"]); // Clears "foo.bar" and "foo.baz" respectiv
 
 ### runValidation
 
-`(name?: string | string[] | null, shouldFocus?: boolean) => Promise<boolean>`
+`(name?: string | string[]) => Promise<boolean>`
 
 This method allows us to manually run validation for the form or field(s).
 
 - It returns a `boolean` that indicates the validation results, `true` means valid, `false` otherwise.
-- We can apply focus to the first field with an error via the `shouldFocus` parameter (default = false). See the [use case](../examples/wizard-form).
 - Please note, when enabling the [Filter Untouched Field Errors](../getting-started/form-state#filter-untouched-field-errors), only the errors of the touched fields are accessible.
 
 ```js
@@ -426,18 +425,12 @@ const { runValidation } = useForm();
 
 // Validates the form (i.e. all the fields)
 runValidation();
-// Will apply focus to the first field with an error
-runValidation(null, true);
 
 // Validates single field
 runValidation("fieldName");
-// Will apply focus to a field with an error
-runValidation("fieldName", true);
 
 // Validates multiple fields
 runValidation(["fieldName1", "fieldName2"]);
-// Will apply focus to the first field with an error, the focus order will be: "fieldName1" → "fieldName2"
-runValidation(["fieldName1", "fieldName2"], true);
 
 // With result
 const validateForm = async () => {

--- a/docs/getting-started/validation-guide.md
+++ b/docs/getting-started/validation-guide.md
@@ -248,8 +248,6 @@ const App = () => {
       </button>
       {/* Validate the form (i.e. all the fields) */}
       <button onClick={() => runValidation()}>Validate All</button>
-      {/* Validate the form (or fields) and apply focus to the field with an error */}
-      <button onClick={() => runValidation(null, true)}>Validate All</button>
       {/* With result */}
       <button
         onClick={async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,7 +246,7 @@ export interface ClearErrors {
 }
 
 export interface RunValidation {
-  (name?: string | string[] | null, shouldFocus?: boolean): Promise<boolean>;
+  (name?: string | string[]): Promise<boolean>;
 }
 
 export interface Reset<V = any> {

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -83,7 +83,7 @@ declare module "react-cool-form" {
   }
 
   interface RunValidation {
-    (name?: string | string[] | null, shouldFocus?: boolean): Promise<boolean>;
+    (name?: string | string[]): Promise<boolean>;
   }
 
   interface Reset<V> {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1452,32 +1452,6 @@ describe("useForm", () => {
       isValid = await runValidation(["foo"]);
       expect(isValid).toBeFalsy();
     });
-
-    it("should focus correctly", async () => {
-      const { runValidation } = renderHelper({
-        children: (
-          <>
-            <input data-testid="foo" name="foo" />
-            <input data-testid="bar" name="bar" required />
-            <input data-testid="baz" name="baz" required />
-          </>
-        ),
-      });
-
-      runValidation();
-      await waitFor(() => expect(getByTestId("foo")).not.toHaveFocus());
-
-      runValidation(null, true);
-      await waitFor(() => expect(getByTestId("bar")).toHaveFocus());
-
-      runValidation("foo", true);
-      await waitFor(() => expect(getByTestId("foo")).not.toHaveFocus());
-      runValidation("bar", true);
-      await waitFor(() => expect(getByTestId("bar")).toHaveFocus());
-
-      runValidation(["foo", "baz", "bar"], true);
-      await waitFor(() => expect(getByTestId("baz")).toHaveFocus());
-    });
   });
 
   describe("mon", () => {


### PR DESCRIPTION
- Refactor(useForm): deprecate the `shouldFocus` parameter of `runValidation` API