### PR TITLE
Fix(useForm): when dynamically hide a field `getState("foo")` will get the default value

### DIFF
--- a/.changeset/weak-dragons-act.md
+++ b/.changeset/weak-dragons-act.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useForm): when dynamically hidding a field `getState` method will get default value

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -541,6 +541,8 @@ export default <V extends FormValues = FormValues>({
           return p;
         },
         (p, v) => {
+          if (methodName === "getState") return v;
+
           if (p.startsWith("values")) {
             if (!isUndefined(v)) return v;
 


### PR DESCRIPTION
- Fix(useForm): when dynamically hide a field `getState("foo")` will get the default value