### PR TITLE
Fix(useControlled): value not updated when working with conditional fields and setting default value from `defaultValue` option

### DIFF
--- a/.changeset/cyan-bees-pretend.md
+++ b/.changeset/cyan-bees-pretend.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Fix(useControlled): value not updated when working with conditional fields and setting default value from `defaultValue` option

--- a/src/useControlled.ts
+++ b/src/useControlled.ts
@@ -92,7 +92,7 @@ export default <V extends FormValues = FormValues>(
     value = defaultValue;
 
     if (!isUndefined(defaultValue)) {
-      setDefaultValue(name, defaultValue);
+      setDefaultValue(name, defaultValue, true);
     } else if (!isFieldArr && !hasWarn.current) {
       warn(
         `💡 react-cool-form > useControlled: Please provide a default value for "${name}" field.`


### PR DESCRIPTION
- Fix(useControlled): value not updated when working with conditional fields and setting default value from `defaultValue` option