### PR TITLE
Refactor(useForm): rename `debug` event to `onStateChange`

### DIFF
--- a/.changeset/grumpy-moons-design.md
+++ b/.changeset/grumpy-moons-design.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+Refactor(useForm): rename `debug` event to `onStateChange`

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -223,17 +223,18 @@ const methods = useForm({
 
 👉🏻 See the [Reset Form](../getting-started/reset-form) to learn more.
 
-### debug
-
-A callback for debugging that receives the form state. It's called on every state change.
+### onStateChange
 
 `(formState: FormState) => void`
 
+The form state change handler that is called on every state change. It's useful for **debugging** or **triggering a handler**.
+
+- Want to trigger a handler based on certain properties in the form state? Check out the [useFormState](../api-reference/use-form-state) to learn more.
 - `formState` is readonly and should not be mutated directly.
 
 ```js
 const methods = useForm({
-  debug: (formState) => console.log("Debug: ", formState),
+  onStateChange: (formState) => console.log("State: ", formState),
 });
 ```
 

--- a/src/hooks/useState.test.ts
+++ b/src/hooks/useState.test.ts
@@ -24,9 +24,9 @@ describe("useState", () => {
     isSubmitted: false,
     submitCount: 0,
   };
-  const renderHelper = (debug?: (state: any) => void) => {
+  const renderHelper = (onChange?: (state: any) => void) => {
     const { observersRef, ...rest } = renderHook(() =>
-      useState(initialState, debug)
+      useState(initialState, onChange)
     ).result.current;
 
     return { observer: observersRef.current[0], ...rest };
@@ -225,11 +225,11 @@ describe("useState", () => {
   });
 
   it("should skip re-render", () => {
-    const debug = jest.fn();
-    const { setStateRef, observer } = renderHelper(debug);
+    const onChange = jest.fn();
+    const { setStateRef, observer } = renderHelper(onChange);
     observer.usedState = { values: true };
     setStateRef("values.foo", "🍎", { shouldSkipUpdate: true });
-    expect(debug).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalled();
     expect(forceUpdate).not.toHaveBeenCalled();
   });
 
@@ -251,27 +251,27 @@ describe("useState", () => {
     expect(forceUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("should call debug correctly when setting state", () => {
-    const debug = jest.fn();
-    const { setStateRef } = renderHelper(debug);
+  it('should trigger "onChange" correctly when setting state', () => {
+    const onChange = jest.fn();
+    const { setStateRef } = renderHelper(onChange);
     const state = {
       ...initialState,
       values: { ...initialState.values, foo: "🍎" },
     };
     setStateRef("", state);
     setStateRef("", state);
-    expect(debug).toHaveBeenCalledTimes(1);
-    expect(debug).toHaveBeenCalledWith(state);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(state);
   });
 
-  it("should call debug correctly when setting values", () => {
-    const debug = jest.fn();
-    const { setStateRef } = renderHelper(debug);
+  it('should trigger "onChange" correctly when setting values', () => {
+    const onChange = jest.fn();
+    const { setStateRef } = renderHelper(onChange);
     const errors = { foo: "Required" };
     setStateRef("errors", errors);
     setStateRef("errors", errors);
-    expect(debug).toHaveBeenCalledTimes(1);
-    expect(debug).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
       ...initialState,
       errors,
       isValid: false,

--- a/src/hooks/useState.ts
+++ b/src/hooks/useState.ts
@@ -2,10 +2,10 @@ import { useReducer, useRef, useCallback } from "react";
 import { dequal } from "dequal/lite";
 
 import {
-  Debug,
   FormState,
   FormStateReturn,
   Observer,
+  OnStateChange,
   SetStateRef,
 } from "../types";
 import useLatest from "./useLatest";
@@ -13,7 +13,7 @@ import { get, getIsDirty, isEmptyObject, set } from "../utils";
 
 export default <V>(
   initialState: FormState<V>,
-  onChange?: Debug<V>
+  onChange?: OnStateChange<V>
 ): FormStateReturn<V> => {
   const [, forceUpdate] = useReducer((c) => c + 1, 0);
   const stateRef = useRef(initialState);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,7 +126,7 @@ export interface ErrorHandler<V = any> {
   ): void;
 }
 
-export interface Debug<V> {
+export interface OnStateChange<V> {
   (formState: FormState<V>): void;
 }
 
@@ -287,7 +287,7 @@ export type FormConfig<V = any> = Partial<{
   onReset: ResetHandler<V>;
   onSubmit: SubmitHandler<V>;
   onError: ErrorHandler<V>;
-  debug: Debug<V>;
+  onStateChange: OnStateChange<V>;
 }>;
 
 export interface FormMethods<V = any> {

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -178,7 +178,7 @@ declare module "react-cool-form" {
     ): void;
   }
 
-  export interface Debug<V extends FormValues = FormValues> {
+  export interface OnStateChange<V extends FormValues = FormValues> {
     (formState: FormState<V>): void;
   }
 
@@ -195,7 +195,7 @@ declare module "react-cool-form" {
     onReset: ResetHandler<V>;
     onSubmit: SubmitHandler<V>;
     onError: ErrorHandler<V>;
-    debug: Debug<V>;
+    onStateChange: OnStateChange<V>;
   }>;
 
   export interface FormMethods<V extends FormValues = FormValues> {

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1962,18 +1962,21 @@ describe("useForm", () => {
     expect(getState("foo")).toBe(type === "normal" ? undefined : value);
   });
 
-  it("should call debug callback", async () => {
-    const debug = jest.fn();
-    renderHelper({ debug, children: <input data-testid="foo" name="foo" /> });
+  it('should trigger "onStateChange" correctly', async () => {
+    const onStateChange = jest.fn();
+    renderHelper({
+      onStateChange,
+      children: <input data-testid="foo" name="foo" />,
+    });
     const value = "🍎";
     fireEvent.input(getByTestId("foo"), { target: { value } });
     await waitFor(() => {
-      expect(debug).toHaveBeenCalledTimes(2);
-      expect(debug).toHaveBeenNthCalledWith(1, {
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenNthCalledWith(1, {
         ...initialState,
         values: { foo: value },
       });
-      expect(debug).toHaveBeenNthCalledWith(2, {
+      expect(onStateChange).toHaveBeenNthCalledWith(2, {
         ...initialState,
         values: { foo: value },
         dirty: { foo: true },

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -83,7 +83,7 @@ export default <V extends FormValues = FormValues>({
   onReset,
   onSubmit,
   onError,
-  debug,
+  onStateChange,
 }: FormConfig<V> = {}): FormMethods<V> => {
   const handlersRef = useRef<Handlers>({});
   const mutationObserverRef = useRef<MutationObserver>();
@@ -114,7 +114,7 @@ export default <V extends FormValues = FormValues>({
   });
   const { stateRef, setStateRef, observersRef } = useState<V>(
     initialStateRef.current,
-    debug
+    onStateChange
   );
 
   const handleUnset = useCallback(


### PR DESCRIPTION
- Refactor(useForm): rename `debug` event to `onStateChange`