### PR TITLE
Refactor(useForm): turn the 3rd parameter of `setTouched` to an option for the purpose of API consistency

### DIFF
--- a/.changeset/moody-peaches-protect.md
+++ b/.changeset/moody-peaches-protect.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": minor
+---
+
+Refactor(useForm): turn the `shouldValidate` parameter of `setTouched` to object for the purpose of API consistency

--- a/docs/api-reference/use-form.md
+++ b/docs/api-reference/use-form.md
@@ -350,7 +350,7 @@ setValue("fieldName", undefined); // The field will be unset: { fieldName: "valu
 
 ### setTouched
 
-`(name: string, isTouched?: boolean, shouldValidate?: boolean) => void`
+`(name: string, isTouched?: boolean, options?: Object) => void`
 
 This method allows us to manually set/clear the touched of a field. Useful for creating custom field touched handlers.
 
@@ -361,11 +361,9 @@ const { setTouched } = useForm();
 setTouched("fieldName");
 
 // Full parameters
-setTouched(
-  "fieldName",
-  true, // (Default = true) Sets the field as touched
-  true // (Default = "validateOnBlur" option) Triggers field validation
-);
+// 2nd: (Default = true) Sets the field as touched
+// 3rd: (Default = "validateOnBlur" option) Triggers field validation
+setTouched("fieldName", true, { shouldValidate: true });
 ```
 
 We can clear the touched of a field by the following way:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,7 +236,11 @@ export interface SetValue {
 }
 
 export interface SetTouched {
-  (name: string, isTouched?: boolean, shouldValidate?: boolean): void;
+  (
+    name: string,
+    isTouched?: boolean,
+    options?: { shouldValidate?: boolean }
+  ): void;
 }
 
 export interface SetDirty {

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -154,8 +154,12 @@ declare module "react-cool-form" {
     ): void;
   }
 
+  export type SetTouchedOptions = {
+    shouldValidate?: boolean;
+  };
+
   export interface SetTouched {
-    (name: string, isTouched?: boolean, shouldValidate?: boolean): void;
+    (name: string, isTouched?: boolean, options?: SetTouchedOptions): void;
   }
 
   export interface SetDirty {

--- a/src/useControlled.test.tsx
+++ b/src/useControlled.test.tsx
@@ -529,7 +529,7 @@ describe("useControlled", () => {
 
         act(() => {
           setError("foo", "Required");
-          setTouched("foo", true, false);
+          setTouched("foo", true, { shouldValidate: false });
           setDirty("foo");
           setShow(false);
         });
@@ -563,7 +563,7 @@ describe("useControlled", () => {
 
         act(() => {
           setError("foo", "Required");
-          setTouched("foo", true, false);
+          setTouched("foo", true, { shouldValidate: false });
           setDirty("foo");
           setShow(false);
         });

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -505,8 +505,8 @@ describe("useFieldArray", () => {
 
       act(() => {
         setError("foo", [{ a: "Required", b: "Required" }]);
-        setTouched("foo[0].a", true, false);
-        setTouched("foo[0].b", true, false);
+        setTouched("foo[0].a", true, { shouldValidate: false });
+        setTouched("foo[0].b", true, { shouldValidate: false });
         setDirty("foo[0].a");
         setDirty("foo[0].b");
         setShow(false);
@@ -547,8 +547,8 @@ describe("useFieldArray", () => {
 
       act(() => {
         setError("foo", [{ a: "Required", b: "Required" }]);
-        setTouched("foo[0].a", true, false);
-        setTouched("foo[0].b", true, false);
+        setTouched("foo[0].a", true, { shouldValidate: false });
+        setTouched("foo[0].b", true, { shouldValidate: false });
         setDirty("foo[0].a");
         setDirty("foo[0].b");
         setShow(false);
@@ -625,8 +625,8 @@ describe("useFieldArray", () => {
 
         act(() => {
           setError("foo", [{ a: "Required", b: "Required" }]);
-          setTouched("foo[0].a", true, false);
-          setTouched("foo[0].b", true, false);
+          setTouched("foo[0].a", true, { shouldValidate: false });
+          setTouched("foo[0].b", true, { shouldValidate: false });
           setDirty("foo[0].a");
           setDirty("foo[0].b");
           setShow(false);
@@ -659,8 +659,8 @@ describe("useFieldArray", () => {
 
         act(() => {
           setError("foo", [{ a: "Required", b: "Required" }]);
-          setTouched("foo[0].a", true, false);
-          setTouched("foo[0].b", true, false);
+          setTouched("foo[0].a", true, { shouldValidate: false });
+          setTouched("foo[0].b", true, { shouldValidate: false });
           setDirty("foo[0].a");
           setDirty("foo[0].b");
           setShow(false);
@@ -712,8 +712,8 @@ describe("useFieldArray", () => {
 
         act(() => {
           setError("foo", [{ a: "Required", b: "Required" }]);
-          setTouched("foo[0].a", true, false);
-          setTouched("foo[0].b", true, false);
+          setTouched("foo[0].a", true, { shouldValidate: false });
+          setTouched("foo[0].b", true, { shouldValidate: false });
           setDirty("foo[0].a");
           setDirty("foo[0].b");
           setShow(false);

--- a/src/useForm.test.tsx
+++ b/src/useForm.test.tsx
@@ -1839,7 +1839,7 @@ describe("useForm", () => {
         children: <input data-testid="foo" name="foo" required />,
       });
 
-      setTouched("foo", true, false);
+      setTouched("foo", true, { shouldValidate: false });
       await waitFor(() => expect(getState("errors.foo")).toBeUndefined());
 
       setTouched("foo");
@@ -1957,7 +1957,7 @@ describe("useForm", () => {
 
     act(() => {
       setError("foo", "Required");
-      setTouched("foo", true, false);
+      setTouched("foo", true, { shouldValidate: false });
       setDirty("foo");
       removeField(
         "foo",
@@ -2044,7 +2044,7 @@ describe("useForm", () => {
 
         act(() => {
           setError("foo", "Required");
-          setTouched("foo", true, false);
+          setTouched("foo", true, { shouldValidate: false });
           setDirty("foo");
           setShow(false);
         });
@@ -2101,7 +2101,7 @@ describe("useForm", () => {
 
         act(() => {
           setError("foo", "Required");
-          setTouched("foo", true, false);
+          setTouched("foo", true, { shouldValidate: false });
           setDirty("foo");
           setShow(false);
         });
@@ -2159,7 +2159,7 @@ describe("useForm", () => {
 
         act(() => {
           setError("foo", "Required");
-          setTouched("foo", true, false);
+          setTouched("foo", true, { shouldValidate: false });
           setDirty("foo");
           setShow(false);
         });
@@ -2194,7 +2194,7 @@ describe("useForm", () => {
       act(() => {
         setValue("foo", "🍎", { shouldValidate: false });
         setError("foo", "Required");
-        setTouched("foo", true, false);
+        setTouched("foo", true, { shouldValidate: false });
         setDirty("foo");
       });
       act(() => setShow(false));

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -610,7 +610,7 @@ export default <V extends FormValues = FormValues>({
   );
 
   const setTouched = useCallback<SetTouched>(
-    (name, isTouched = true, shouldValidate = validateOnBlur) => {
+    (name, isTouched = true, { shouldValidate = validateOnBlur } = {}) => {
       if (isTouched) {
         setStateRef(`touched.${name}`, true);
       } else {
@@ -624,11 +624,11 @@ export default <V extends FormValues = FormValues>({
 
   const setTouchedMaybeValidate = useCallback<SetTouchedMaybeValidate>(
     (name) =>
-      setTouched(
-        name,
-        true,
-        validateOnChange ? name !== changedFieldRef.current : undefined
-      ),
+      setTouched(name, true, {
+        shouldValidate: validateOnChange
+          ? name !== changedFieldRef.current
+          : undefined,
+      }),
     [setTouched, validateOnChange]
   );
 
@@ -680,7 +680,7 @@ export default <V extends FormValues = FormValues>({
         fieldArrayRef.current[key].reset()
       );
 
-      if (shouldTouched) setTouched(name, true, false);
+      if (shouldTouched) setTouched(name, true, { shouldValidate: false });
       if (shouldDirty) setDirtyIfNeeded(name);
       if (shouldValidate) validateFieldWithLowPriority(name);
     },


### PR DESCRIPTION
- Refactor(useForm): turn the 3rd parameter of `setTouched` to an option for the purpose of API consistency