### PR TITLE
refactor(types): use `RefObject` as the type of `form` method

### DIFF
--- a/.changeset/empty-tools-complain.md
+++ b/.changeset/empty-tools-complain.md
@@ -1,0 +1,5 @@
+---
+"react-cool-form": patch
+---
+
+refactor(types): use `RefObject` as the type of `form` method

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,9 @@
-import { FocusEventHandler, MutableRefObject, SyntheticEvent } from "react";
+import {
+  FocusEventHandler,
+  MutableRefObject,
+  RefCallback,
+  SyntheticEvent,
+} from "react";
 
 // Utils
 export type ObjMap<T = boolean> = Record<string, T>;
@@ -140,9 +145,7 @@ interface FormValidator<V> {
     | Promise<FormErrors<V> | false | void>;
 }
 
-export interface RegisterForm {
-  (element: HTMLElement | null): void;
-}
+export type RegisterForm = RefCallback<HTMLElement>;
 
 export interface FieldValidator<V> {
   (value: any, values: V): any | Promise<any>;

--- a/src/types/react-cool-form.d.ts
+++ b/src/types/react-cool-form.d.ts
@@ -1,5 +1,5 @@
 declare module "react-cool-form" {
-  import { FocusEventHandler, SyntheticEvent } from "react";
+  import { FocusEventHandler, RefCallback, SyntheticEvent } from "react";
 
   // Type utils
   type ObjMap<T = boolean> = Record<string, T>;
@@ -96,9 +96,7 @@ declare module "react-cool-form" {
     (formState: FormState<V>): void;
   }
 
-  export interface RegisterForm {
-    (element: HTMLElement | null): void;
-  }
+  export type RegisterForm = RefCallback<HTMLElement>;
 
   export interface RegisterFieldReturn {
     (


### PR DESCRIPTION
- refactor(types): use `RefObject` as the type of `form` method